### PR TITLE
fix: prevent icon duplication and preserve favorites ordering

### DIFF
--- a/src/icon/cache.rs
+++ b/src/icon/cache.rs
@@ -1,0 +1,669 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+use std::fs;
+use std::io::Write;
+
+use bevy::prelude::Handle;
+use bevy::render::texture::Image;
+use lru::LruCache;
+use serde::{Deserialize, Serialize};
+
+use crate::icon::types::IconError;
+
+/// Cached icon entry in memory
+#[derive(Debug, Clone)]
+pub struct CachedIcon {
+    /// Bevy image handle for the loaded icon
+    pub handle: Handle<Image>,
+    /// Path to the icon file
+    pub path: PathBuf,
+    /// When this icon was last accessed
+    pub last_used: Instant,
+    /// When this icon was first cached
+    pub cached_at: Instant,
+    /// Number of times this icon has been accessed
+    pub access_count: u64,
+}
+
+impl CachedIcon {
+    /// Create a new cached icon entry
+    pub fn new(handle: Handle<Image>, path: PathBuf) -> Self {
+        let now = Instant::now();
+        Self {
+            handle,
+            path,
+            last_used: now,
+            cached_at: now,
+            access_count: 1,
+        }
+    }
+
+    /// Mark this icon as accessed
+    pub fn mark_accessed(&mut self) {
+        self.last_used = Instant::now();
+        self.access_count += 1;
+    }
+
+    /// Get the age of this cached entry
+    pub fn age(&self) -> Duration {
+        self.cached_at.elapsed()
+    }
+
+    /// Get time since last access
+    pub fn time_since_last_access(&self) -> Duration {
+        self.last_used.elapsed()
+    }
+}
+
+/// Persistent cache entry for disk storage
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistentCacheEntry {
+    /// Path to the icon file
+    path: PathBuf,
+    /// When this entry was created
+    created_at: u64, // Unix timestamp
+    /// Number of times this has been used
+    usage_count: u64,
+    /// Last time this was accessed
+    last_accessed: u64, // Unix timestamp
+}
+
+impl PersistentCacheEntry {
+    fn new(path: PathBuf) -> Self {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        
+        Self {
+            path,
+            created_at: now,
+            usage_count: 1,
+            last_accessed: now,
+        }
+    }
+
+    fn mark_accessed(&mut self) {
+        self.usage_count += 1;
+        self.last_accessed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+    }
+
+    fn age_seconds(&self) -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .saturating_sub(self.created_at)
+    }
+}
+
+/// Cache metrics for monitoring performance
+#[derive(Debug, Clone, Default)]
+pub struct CacheMetrics {
+    /// Total number of cache hits
+    pub hits: u64,
+    /// Total number of cache misses
+    pub misses: u64,
+    /// Number of entries evicted from memory cache
+    pub evictions: u64,
+    /// Number of persistent cache saves
+    pub persistent_saves: u64,
+    /// Number of persistent cache loads
+    pub persistent_loads: u64,
+    /// Number of cleanup operations performed
+    pub cleanups: u64,
+}
+
+impl CacheMetrics {
+    /// Calculate hit rate as a percentage
+    pub fn hit_rate(&self) -> f64 {
+        let total = self.hits + self.misses;
+        if total == 0 {
+            0.0
+        } else {
+            (self.hits as f64 / total as f64) * 100.0
+        }
+    }
+
+    /// Get total number of requests
+    pub fn total_requests(&self) -> u64 {
+        self.hits + self.misses
+    }
+
+    /// Reset all metrics
+    pub fn reset(&mut self) {
+        *self = Default::default();
+    }
+}
+
+/// Configuration for the icon cache
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    /// Maximum number of icons to keep in memory
+    pub memory_cache_size: usize,
+    /// Whether to enable persistent cache
+    pub enable_persistent_cache: bool,
+    /// Path to persistent cache file
+    pub persistent_cache_path: PathBuf,
+    /// Maximum age for persistent cache entries (in seconds)
+    pub max_persistent_age: u64,
+    /// Maximum number of entries in persistent cache
+    pub max_persistent_entries: usize,
+    /// How often to perform cleanup (in seconds)
+    pub cleanup_interval: u64,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        let cache_dir = dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("anny-dock");
+        
+        Self {
+            memory_cache_size: 100,
+            enable_persistent_cache: true,
+            persistent_cache_path: cache_dir.join("icon_cache.json"),
+            max_persistent_age: 7 * 24 * 60 * 60, // 7 days
+            max_persistent_entries: 1000,
+            cleanup_interval: 60 * 60, // 1 hour
+        }
+    }
+}
+
+/// Icon cache with LRU memory cache and persistent storage
+pub struct IconCache {
+    /// In-memory LRU cache of loaded icons
+    memory_cache: LruCache<String, CachedIcon>,
+    /// Persistent cache mapping class names to icon paths
+    persistent_cache: HashMap<String, PersistentCacheEntry>,
+    /// Cache configuration
+    config: CacheConfig,
+    /// Performance metrics
+    metrics: CacheMetrics,
+    /// Last time cleanup was performed
+    last_cleanup: Instant,
+    /// Whether persistent cache has been modified since last save
+    persistent_dirty: bool,
+}
+
+impl IconCache {
+    /// Create a new icon cache with default configuration
+    pub fn new() -> Self {
+        Self::with_config(CacheConfig::default())
+    }
+
+    /// Create a new icon cache with custom configuration
+    pub fn with_config(config: CacheConfig) -> Self {
+        let memory_cache = LruCache::new(
+            std::num::NonZeroUsize::new(config.memory_cache_size)
+                .unwrap_or(std::num::NonZeroUsize::new(100).unwrap())
+        );
+
+        let mut cache = Self {
+            memory_cache,
+            persistent_cache: HashMap::new(),
+            config,
+            metrics: CacheMetrics::default(),
+            last_cleanup: Instant::now(),
+            persistent_dirty: false,
+        };
+
+        // Load persistent cache if enabled
+        if cache.config.enable_persistent_cache {
+            if let Err(e) = cache.load_persistent_cache() {
+                eprintln!("Warning: Failed to load persistent icon cache: {}", e);
+            }
+        }
+
+        cache
+    }
+
+    /// Get an icon from cache by class name
+    pub fn get(&mut self, class: &str) -> Option<&CachedIcon> {
+        // Check memory cache first
+        if let Some(cached) = self.memory_cache.get_mut(class) {
+            cached.mark_accessed();
+            self.metrics.hits += 1;
+            return Some(cached);
+        }
+
+        self.metrics.misses += 1;
+        None
+    }
+
+    /// Get icon path from persistent cache
+    pub fn get_persistent_path(&mut self, class: &str) -> Option<PathBuf> {
+        if !self.config.enable_persistent_cache {
+            return None;
+        }
+
+        if let Some(entry) = self.persistent_cache.get_mut(class) {
+            // Check if file still exists
+            if entry.path.exists() {
+                entry.mark_accessed();
+                self.persistent_dirty = true;
+                self.metrics.persistent_loads += 1;
+                return Some(entry.path.clone());
+            } else {
+                // File no longer exists, remove from cache
+                self.persistent_cache.remove(class);
+                self.persistent_dirty = true;
+            }
+        }
+
+        None
+    }
+
+    /// Store an icon in the cache
+    pub fn store(&mut self, class: String, icon: CachedIcon) {
+        // Store in memory cache
+        if let Some(_evicted) = self.memory_cache.put(class.clone(), icon.clone()) {
+            self.metrics.evictions += 1;
+        }
+
+        // Store in persistent cache if enabled
+        if self.config.enable_persistent_cache {
+            let entry = PersistentCacheEntry::new(icon.path.clone());
+            self.persistent_cache.insert(class, entry);
+            self.persistent_dirty = true;
+        }
+
+        // Perform cleanup if needed
+        self.maybe_cleanup();
+    }
+
+    /// Store only the path mapping in persistent cache
+    pub fn store_path_mapping(&mut self, class: String, path: PathBuf) {
+        if !self.config.enable_persistent_cache {
+            return;
+        }
+
+        let entry = PersistentCacheEntry::new(path);
+        self.persistent_cache.insert(class, entry);
+        self.persistent_dirty = true;
+        self.maybe_cleanup();
+    }
+
+    /// Remove an entry from all caches
+    pub fn remove(&mut self, class: &str) {
+        self.memory_cache.pop(class);
+        if self.config.enable_persistent_cache {
+            if self.persistent_cache.remove(class).is_some() {
+                self.persistent_dirty = true;
+            }
+        }
+    }
+
+    /// Clear all caches
+    pub fn clear(&mut self) {
+        self.memory_cache.clear();
+        if self.config.enable_persistent_cache {
+            if !self.persistent_cache.is_empty() {
+                self.persistent_cache.clear();
+                self.persistent_dirty = true;
+            }
+        }
+        self.metrics.reset();
+    }
+
+    /// Get current cache metrics
+    pub fn metrics(&self) -> &CacheMetrics {
+        &self.metrics
+    }
+
+    /// Get cache statistics
+    pub fn stats(&self) -> CacheStats {
+        CacheStats {
+            memory_entries: self.memory_cache.len(),
+            memory_capacity: self.memory_cache.cap().get(),
+            persistent_entries: self.persistent_cache.len(),
+            hit_rate: self.metrics.hit_rate(),
+            total_requests: self.metrics.total_requests(),
+        }
+    }
+
+    /// Force cleanup of old entries
+    pub fn cleanup(&mut self) -> Result<(), IconError> {
+        self.cleanup_persistent_cache()?;
+        self.save_persistent_cache()?;
+        self.metrics.cleanups += 1;
+        self.last_cleanup = Instant::now();
+        Ok(())
+    }
+
+    /// Check if cleanup should be performed and do it if needed
+    fn maybe_cleanup(&mut self) {
+        let cleanup_interval = Duration::from_secs(self.config.cleanup_interval);
+        if self.last_cleanup.elapsed() >= cleanup_interval {
+            if let Err(e) = self.cleanup() {
+                eprintln!("Warning: Cache cleanup failed: {}", e);
+            }
+        }
+    }
+
+    /// Load persistent cache from disk
+    fn load_persistent_cache(&mut self) -> Result<(), IconError> {
+        if !self.config.persistent_cache_path.exists() {
+            return Ok(());
+        }
+
+        let content = fs::read_to_string(&self.config.persistent_cache_path)
+            .map_err(|e| IconError::cache_error(format!("Failed to read persistent cache: {}", e)))?;
+
+        let cache: HashMap<String, PersistentCacheEntry> = serde_json::from_str(&content)
+            .map_err(|e| IconError::cache_error(format!("Failed to parse persistent cache: {}", e)))?;
+
+        self.persistent_cache = cache;
+        self.persistent_dirty = false;
+        Ok(())
+    }
+
+    /// Save persistent cache to disk
+    fn save_persistent_cache(&mut self) -> Result<(), IconError> {
+        if !self.config.enable_persistent_cache || !self.persistent_dirty {
+            return Ok(());
+        }
+
+        // Ensure cache directory exists
+        if let Some(parent) = self.config.persistent_cache_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| IconError::cache_error(format!("Failed to create cache directory: {}", e)))?;
+        }
+
+        let content = serde_json::to_string_pretty(&self.persistent_cache)
+            .map_err(|e| IconError::cache_error(format!("Failed to serialize cache: {}", e)))?;
+
+        let mut file = fs::File::create(&self.config.persistent_cache_path)
+            .map_err(|e| IconError::cache_error(format!("Failed to create cache file: {}", e)))?;
+
+        file.write_all(content.as_bytes())
+            .map_err(|e| IconError::cache_error(format!("Failed to write cache file: {}", e)))?;
+
+        self.persistent_dirty = false;
+        self.metrics.persistent_saves += 1;
+        Ok(())
+    }
+
+    /// Clean up old entries from persistent cache
+    fn cleanup_persistent_cache(&mut self) -> Result<(), IconError> {
+        if !self.config.enable_persistent_cache {
+            return Ok(());
+        }
+
+        let max_age = self.config.max_persistent_age;
+        let max_entries = self.config.max_persistent_entries;
+        let mut removed_count = 0;
+
+        // Remove entries that are too old or have invalid paths
+        self.persistent_cache.retain(|_class, entry| {
+            if entry.age_seconds() > max_age || !entry.path.exists() {
+                removed_count += 1;
+                false
+            } else {
+                true
+            }
+        });
+
+        // If still too many entries, remove least recently used
+        if self.persistent_cache.len() > max_entries {
+            let mut entries: Vec<_> = self.persistent_cache.iter().collect();
+            entries.sort_by_key(|(_, entry)| entry.last_accessed);
+            
+            let to_remove = self.persistent_cache.len() - max_entries;
+            let keys_to_remove: Vec<String> = entries.iter()
+                .take(to_remove)
+                .map(|(class, _)| (*class).clone())
+                .collect();
+            
+            for class in keys_to_remove {
+                self.persistent_cache.remove(&class);
+                removed_count += 1;
+            }
+        }
+
+        if removed_count > 0 {
+            self.persistent_dirty = true;
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for IconCache {
+    fn drop(&mut self) {
+        // Save persistent cache on drop
+        if let Err(e) = self.save_persistent_cache() {
+            eprintln!("Warning: Failed to save persistent cache on drop: {}", e);
+        }
+    }
+}
+
+/// Cache statistics for monitoring
+#[derive(Debug, Clone)]
+pub struct CacheStats {
+    /// Number of entries in memory cache
+    pub memory_entries: usize,
+    /// Maximum capacity of memory cache
+    pub memory_capacity: usize,
+    /// Number of entries in persistent cache
+    pub persistent_entries: usize,
+    /// Cache hit rate as percentage
+    pub hit_rate: f64,
+    /// Total number of cache requests
+    pub total_requests: u64,
+}
+
+impl CacheStats {
+    /// Get memory cache utilization as percentage
+    pub fn memory_utilization(&self) -> f64 {
+        if self.memory_capacity == 0 {
+            0.0
+        } else {
+            (self.memory_entries as f64 / self.memory_capacity as f64) * 100.0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_test_config() -> (CacheConfig, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let config = CacheConfig {
+            memory_cache_size: 5,
+            enable_persistent_cache: true,
+            persistent_cache_path: temp_dir.path().join("test_cache.json"),
+            max_persistent_age: 3600, // 1 hour
+            max_persistent_entries: 10,
+            cleanup_interval: 60,
+        };
+        (config, temp_dir)
+    }
+
+    fn create_test_icon() -> CachedIcon {
+        CachedIcon::new(
+            Handle::default(),
+            PathBuf::from("/test/icon.png")
+        )
+    }
+
+    #[test]
+    fn test_cache_creation() {
+        let cache = IconCache::new();
+        assert_eq!(cache.stats().memory_entries, 0);
+        assert_eq!(cache.stats().persistent_entries, 0);
+        assert_eq!(cache.metrics().total_requests(), 0);
+    }
+
+    #[test]
+    fn test_memory_cache_store_and_get() {
+        let mut cache = IconCache::new();
+        let icon = create_test_icon();
+        
+        // Store icon
+        cache.store("test-app".to_string(), icon.clone());
+        
+        // Should be able to retrieve it
+        let retrieved = cache.get("test-app");
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().path, icon.path);
+        
+        // Should be a cache hit
+        assert_eq!(cache.metrics().hits, 1);
+        assert_eq!(cache.metrics().misses, 0);
+    }
+
+    #[test]
+    fn test_cache_miss() {
+        let mut cache = IconCache::new();
+        
+        // Try to get non-existent icon
+        let result = cache.get("non-existent");
+        assert!(result.is_none());
+        
+        // Should be a cache miss
+        assert_eq!(cache.metrics().hits, 0);
+        assert_eq!(cache.metrics().misses, 1);
+    }
+
+    #[test]
+    fn test_lru_eviction() {
+        let (config, _temp_dir) = create_test_config();
+        let mut cache = IconCache::with_config(config);
+        
+        // Fill cache beyond capacity
+        for i in 0..10 {
+            let icon = CachedIcon::new(
+                Handle::default(),
+                PathBuf::from(format!("/test/icon{}.png", i))
+            );
+            cache.store(format!("app{}", i), icon);
+        }
+        
+        // Memory cache should be at capacity
+        assert_eq!(cache.stats().memory_entries, 5);
+        assert!(cache.metrics().evictions > 0);
+        
+        // First few entries should be evicted
+        assert!(cache.get("app0").is_none());
+        assert!(cache.get("app1").is_none());
+        
+        // Last entries should still be there
+        assert!(cache.get("app9").is_some());
+        assert!(cache.get("app8").is_some());
+    }
+
+    #[test]
+    fn test_persistent_cache() {
+        let (config, _temp_dir) = create_test_config();
+        let mut cache = IconCache::with_config(config.clone());
+        
+        // Store path mapping
+        cache.store_path_mapping("test-app".to_string(), PathBuf::from("/test/icon.png"));
+        
+        // Should be able to retrieve from persistent cache
+        let path = cache.get_persistent_path("test-app");
+        assert!(path.is_none()); // File doesn't actually exist
+        
+        // Create a real temporary file
+        let temp_file = _temp_dir.path().join("real_icon.png");
+        fs::write(&temp_file, b"fake icon data").unwrap();
+        
+        cache.store_path_mapping("real-app".to_string(), temp_file.clone());
+        let path = cache.get_persistent_path("real-app");
+        assert_eq!(path, Some(temp_file));
+    }
+
+    #[test]
+    fn test_cache_clear() {
+        let mut cache = IconCache::new();
+        let icon = create_test_icon();
+        
+        // Store some data
+        cache.store("test-app".to_string(), icon);
+        assert_eq!(cache.stats().memory_entries, 1);
+        
+        // Clear cache
+        cache.clear();
+        assert_eq!(cache.stats().memory_entries, 0);
+        assert_eq!(cache.metrics().total_requests(), 0);
+    }
+
+    #[test]
+    fn test_cache_remove() {
+        let mut cache = IconCache::new();
+        let icon = create_test_icon();
+        
+        // Store icon
+        cache.store("test-app".to_string(), icon);
+        assert!(cache.get("test-app").is_some());
+        
+        // Remove icon
+        cache.remove("test-app");
+        assert!(cache.get("test-app").is_none());
+    }
+
+    #[test]
+    fn test_cache_metrics() {
+        let mut cache = IconCache::new();
+        let icon = create_test_icon();
+        
+        // Initial state
+        assert_eq!(cache.metrics().hit_rate(), 0.0);
+        
+        // Store and access
+        cache.store("test-app".to_string(), icon);
+        cache.get("test-app"); // hit
+        cache.get("non-existent"); // miss
+        
+        let metrics = cache.metrics();
+        assert_eq!(metrics.hits, 1);
+        assert_eq!(metrics.misses, 1);
+        assert_eq!(metrics.hit_rate(), 50.0);
+        assert_eq!(metrics.total_requests(), 2);
+    }
+
+    #[test]
+    fn test_cached_icon_access_tracking() {
+        let mut icon = create_test_icon();
+        let initial_count = icon.access_count;
+        let initial_time = icon.last_used;
+        
+        // Wait a bit to ensure time difference
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        
+        icon.mark_accessed();
+        
+        assert_eq!(icon.access_count, initial_count + 1);
+        assert!(icon.last_used > initial_time);
+        assert!(icon.age() > Duration::from_millis(0));
+    }
+
+    #[test]
+    fn test_cache_stats() {
+        let (config, _temp_dir) = create_test_config();
+        let mut cache = IconCache::with_config(config);
+        
+        let stats = cache.stats();
+        assert_eq!(stats.memory_entries, 0);
+        assert_eq!(stats.memory_capacity, 5);
+        assert_eq!(stats.memory_utilization(), 0.0);
+        
+        // Add some entries
+        for i in 0..3 {
+            let icon = create_test_icon();
+            cache.store(format!("app{}", i), icon);
+        }
+        
+        let stats = cache.stats();
+        assert_eq!(stats.memory_entries, 3);
+        assert_eq!(stats.memory_utilization(), 60.0); // 3/5 * 100
+    }
+}

--- a/src/icon/mod.rs
+++ b/src/icon/mod.rs
@@ -1,0 +1,12 @@
+pub mod types;
+pub mod traits;
+pub mod cache;
+pub mod resolver;
+pub mod strategies;
+
+// Re-export main types and traits for when they're needed
+pub use types::*;
+pub use traits::*;
+pub use cache::*;
+pub use resolver::*;
+pub use strategies::*;

--- a/src/icon/resolver.rs
+++ b/src/icon/resolver.rs
@@ -1,0 +1,545 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use tracing::{debug, info, warn, error};
+
+use crate::icon::types::{IconContext, IconResult, IconError};
+use crate::icon::traits::{IconDetectionStrategy, StrategyProvider};
+
+/// Manages and executes icon detection strategies in priority order
+/// 
+/// The IconResolver maintains a collection of strategies and executes them
+/// in priority order until one successfully finds an icon. It provides
+/// strategy registration, priority ordering, and fallback logic.
+pub struct IconResolver {
+    /// Registered strategies, sorted by priority (highest first)
+    strategies: Arc<RwLock<Vec<Box<dyn IconDetectionStrategy>>>>,
+    /// Strategy execution statistics for monitoring
+    stats: Arc<RwLock<HashMap<String, StrategyStats>>>,
+}
+
+impl std::fmt::Debug for IconResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let strategy_count = self.strategy_count();
+        f.debug_struct("IconResolver")
+            .field("strategy_count", &strategy_count)
+            .finish()
+    }
+}
+
+/// Statistics for strategy execution monitoring
+#[derive(Debug, Clone, Default)]
+struct StrategyStats {
+    /// Number of times this strategy was attempted
+    attempts: u64,
+    /// Number of successful icon detections
+    successes: u64,
+    /// Total execution time in microseconds
+    total_execution_time_us: u64,
+}
+
+impl IconResolver {
+    /// Create a new IconResolver with no strategies
+    pub fn new() -> Self {
+        Self {
+            strategies: Arc::new(RwLock::new(Vec::new())),
+            stats: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a single strategy
+    /// 
+    /// The strategy will be inserted in the correct position based on its priority.
+    /// Higher priority strategies are executed first.
+    pub fn register_strategy(&mut self, mut strategy: Box<dyn IconDetectionStrategy>) -> Result<(), IconError> {
+        let strategy_name = strategy.name().to_string();
+        
+        // Initialize the strategy
+        if let Err(e) = strategy.initialize() {
+            error!("Failed to initialize strategy '{}': {}", strategy_name, e);
+            return Err(IconError::strategy_error(strategy_name, format!("Initialization failed: {}", e)));
+        }
+
+        // Check if strategy is available
+        if !strategy.is_available() {
+            warn!("Strategy '{}' is not available, skipping registration", strategy_name);
+            return Ok(());
+        }
+
+        let priority = strategy.priority();
+        
+        // Insert strategy in priority order (highest priority first)
+        let mut strategies = self.strategies.write().map_err(|e| {
+            IconError::strategy_error(&strategy_name, format!("Failed to acquire write lock: {}", e))
+        })?;
+
+        let insert_pos = strategies
+            .iter()
+            .position(|s| s.priority() < priority)
+            .unwrap_or(strategies.len());
+
+        strategies.insert(insert_pos, strategy);
+
+        // Initialize stats for this strategy
+        let mut stats = self.stats.write().map_err(|e| {
+            IconError::strategy_error(&strategy_name, format!("Failed to acquire stats write lock: {}", e))
+        })?;
+        stats.insert(strategy_name.clone(), StrategyStats::default());
+
+        info!("Registered strategy '{}' with priority {}", strategy_name, priority);
+        Ok(())
+    }
+
+    /// Register multiple strategies from a provider
+    pub fn register_provider(&mut self, provider: Box<dyn StrategyProvider>) -> Result<(), IconError> {
+        let provider_name = provider.provider_name();
+        debug!("Registering strategies from provider '{}'", provider_name);
+
+        let strategies = provider.get_strategies();
+        let mut registered_count = 0;
+        let mut errors = Vec::new();
+
+        for strategy in strategies {
+            match self.register_strategy(strategy) {
+                Ok(()) => registered_count += 1,
+                Err(e) => errors.push(e),
+            }
+        }
+
+        if !errors.is_empty() {
+            warn!("Provider '{}' had {} registration errors", provider_name, errors.len());
+            for error in &errors {
+                warn!("  - {}", error);
+            }
+        }
+
+        info!("Provider '{}' registered {} strategies", provider_name, registered_count);
+        Ok(())
+    }
+
+    /// Remove a strategy by name
+    pub fn remove_strategy(&mut self, name: &str) -> Result<bool, IconError> {
+        let mut strategies = self.strategies.write().map_err(|e| {
+            IconError::strategy_error(name, format!("Failed to acquire write lock: {}", e))
+        })?;
+
+        if let Some(pos) = strategies.iter().position(|s| s.name() == name) {
+            let mut removed_strategy = strategies.remove(pos);
+            removed_strategy.cleanup();
+            
+            // Remove stats
+            let mut stats = self.stats.write().map_err(|e| {
+                IconError::strategy_error(name, format!("Failed to acquire stats write lock: {}", e))
+            })?;
+            stats.remove(name);
+
+            info!("Removed strategy '{}'", name);
+            Ok(true)
+        } else {
+            debug!("Strategy '{}' not found for removal", name);
+            Ok(false)
+        }
+    }
+
+    /// Get list of registered strategy names in priority order
+    pub fn list_strategies(&self) -> Result<Vec<String>, IconError> {
+        let strategies = self.strategies.read().map_err(|e| {
+            IconError::strategy_error("resolver", format!("Failed to acquire read lock: {}", e))
+        })?;
+
+        Ok(strategies.iter().map(|s| s.name().to_string()).collect())
+    }
+
+    /// Get strategy execution statistics
+    pub fn get_stats(&self) -> Result<HashMap<String, (u64, u64, f64)>, IconError> {
+        let stats = self.stats.read().map_err(|e| {
+            IconError::strategy_error("resolver", format!("Failed to acquire stats read lock: {}", e))
+        })?;
+
+        Ok(stats.iter().map(|(name, stat)| {
+            let avg_time_us = if stat.attempts > 0 {
+                stat.total_execution_time_us as f64 / stat.attempts as f64
+            } else {
+                0.0
+            };
+            (name.clone(), (stat.attempts, stat.successes, avg_time_us))
+        }).collect())
+    }
+
+    /// Clear all strategies and statistics
+    pub fn clear(&mut self) -> Result<(), IconError> {
+        let mut strategies = self.strategies.write().map_err(|e| {
+            IconError::strategy_error("resolver", format!("Failed to acquire write lock: {}", e))
+        })?;
+
+        // Cleanup all strategies
+        for strategy in strategies.iter_mut() {
+            strategy.cleanup();
+        }
+        strategies.clear();
+
+        // Clear stats
+        let mut stats = self.stats.write().map_err(|e| {
+            IconError::strategy_error("resolver", format!("Failed to acquire stats write lock: {}", e))
+        })?;
+        stats.clear();
+
+        info!("Cleared all strategies and statistics");
+        Ok(())
+    }
+
+    /// Resolve an icon using registered strategies
+    /// 
+    /// Executes strategies in priority order until one returns a successful result.
+    /// Returns the first successful result, or None if all strategies fail.
+    pub fn resolve(&self, context: &IconContext) -> Option<IconResult> {
+        let strategies = match self.strategies.read() {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Failed to acquire read lock for strategies: {}", e);
+                return None;
+            }
+        };
+
+        if strategies.is_empty() {
+            warn!("No strategies registered for icon resolution");
+            return None;
+        }
+
+        debug!("Resolving icon for class '{}' using {} strategies", 
+               context.class, strategies.len());
+
+        for strategy in strategies.iter() {
+            let strategy_name = strategy.name();
+            
+            // Check if strategy is still available
+            if !strategy.is_available() {
+                debug!("Strategy '{}' is not available, skipping", strategy_name);
+                continue;
+            }
+
+            debug!("Trying strategy '{}' for class '{}'", strategy_name, context.class);
+            
+            let start_time = std::time::Instant::now();
+            let result = strategy.detect_icon(context);
+            let execution_time = start_time.elapsed();
+
+            // Update statistics
+            if let Ok(mut stats) = self.stats.write() {
+                let strategy_stats = stats.entry(strategy_name.to_string()).or_default();
+                strategy_stats.attempts += 1;
+                strategy_stats.total_execution_time_us += execution_time.as_micros() as u64;
+
+                if result.is_some() {
+                    strategy_stats.successes += 1;
+                }
+            }
+
+            match result {
+                Some(icon_result) => {
+                    info!("Strategy '{}' found icon for class '{}': {:?}", 
+                          strategy_name, context.class, icon_result.path);
+                    debug!("Strategy '{}' execution time: {:?}", strategy_name, execution_time);
+                    return Some(icon_result);
+                }
+                None => {
+                    debug!("Strategy '{}' failed to find icon for class '{}'", 
+                           strategy_name, context.class);
+                }
+            }
+        }
+
+        warn!("All {} strategies failed to find icon for class '{}'", 
+              strategies.len(), context.class);
+        None
+    }
+
+    /// Get the number of registered strategies
+    pub fn strategy_count(&self) -> usize {
+        self.strategies.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Check if a strategy with the given name is registered
+    pub fn has_strategy(&self, name: &str) -> bool {
+        self.strategies.read()
+            .map(|s| s.iter().any(|strategy| strategy.name() == name))
+            .unwrap_or(false)
+    }
+}
+
+impl Default for IconResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Implement Drop to ensure cleanup
+impl Drop for IconResolver {
+    fn drop(&mut self) {
+        if let Err(e) = self.clear() {
+            error!("Error during IconResolver cleanup: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use crate::icon::types::{IconMetadata, IconFormat};
+
+    // Mock strategy for testing
+    struct MockStrategy {
+        name: &'static str,
+        priority: u8,
+        should_succeed: bool,
+        available: bool,
+    }
+
+    impl MockStrategy {
+        fn new(name: &'static str, priority: u8, should_succeed: bool) -> Self {
+            Self {
+                name,
+                priority,
+                should_succeed,
+                available: true,
+            }
+        }
+
+        fn unavailable(name: &'static str, priority: u8) -> Self {
+            Self {
+                name,
+                priority,
+                should_succeed: false,
+                available: false,
+            }
+        }
+    }
+
+    impl IconDetectionStrategy for MockStrategy {
+        fn detect_icon(&self, context: &IconContext) -> Option<IconResult> {
+            if self.should_succeed {
+                Some(IconResult::new(
+                    PathBuf::from(format!("/mock/{}.png", context.class)),
+                    self.name.to_string(),
+                    1.0,
+                    IconMetadata::new(IconFormat::Png),
+                ))
+            } else {
+                None
+            }
+        }
+
+        fn priority(&self) -> u8 {
+            self.priority
+        }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        fn is_available(&self) -> bool {
+            self.available
+        }
+    }
+
+    #[test]
+    fn test_resolver_creation() {
+        let resolver = IconResolver::new();
+        assert_eq!(resolver.strategy_count(), 0);
+    }
+
+    #[test]
+    fn test_strategy_registration() {
+        let mut resolver = IconResolver::new();
+        
+        let strategy = Box::new(MockStrategy::new("test", 50, true));
+        resolver.register_strategy(strategy).unwrap();
+        
+        assert_eq!(resolver.strategy_count(), 1);
+        assert!(resolver.has_strategy("test"));
+    }
+
+    #[test]
+    fn test_strategy_priority_ordering() {
+        let mut resolver = IconResolver::new();
+        
+        // Register strategies in random order
+        resolver.register_strategy(Box::new(MockStrategy::new("low", 10, false))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("high", 90, true))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("medium", 50, false))).unwrap();
+        
+        let strategies = resolver.list_strategies().unwrap();
+        assert_eq!(strategies, vec!["high", "medium", "low"]);
+    }
+
+    #[test]
+    fn test_strategy_execution_order() {
+        let mut resolver = IconResolver::new();
+        
+        // Register high priority failing strategy and low priority succeeding strategy
+        resolver.register_strategy(Box::new(MockStrategy::new("high_fail", 90, false))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("low_success", 10, true))).unwrap();
+        
+        let context = IconContext::new("test-class".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "low_success");
+    }
+
+    #[test]
+    fn test_first_success_wins() {
+        let mut resolver = IconResolver::new();
+        
+        // Register multiple succeeding strategies
+        resolver.register_strategy(Box::new(MockStrategy::new("first", 90, true))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("second", 80, true))).unwrap();
+        
+        let context = IconContext::new("test-class".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "first");
+    }
+
+    #[test]
+    fn test_unavailable_strategy_skipped() {
+        let mut resolver = IconResolver::new();
+        
+        // Register unavailable high priority and available low priority
+        resolver.register_strategy(Box::new(MockStrategy::unavailable("unavailable", 90))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("available", 10, true))).unwrap();
+        
+        let context = IconContext::new("test-class".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "available");
+    }
+
+    #[test]
+    fn test_no_strategies_returns_none() {
+        let resolver = IconResolver::new();
+        let context = IconContext::new("test-class".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_all_strategies_fail() {
+        let mut resolver = IconResolver::new();
+        
+        resolver.register_strategy(Box::new(MockStrategy::new("fail1", 90, false))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("fail2", 80, false))).unwrap();
+        
+        let context = IconContext::new("test-class".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_strategy_removal() {
+        let mut resolver = IconResolver::new();
+        
+        resolver.register_strategy(Box::new(MockStrategy::new("test", 50, true))).unwrap();
+        assert!(resolver.has_strategy("test"));
+        
+        let removed = resolver.remove_strategy("test").unwrap();
+        assert!(removed);
+        assert!(!resolver.has_strategy("test"));
+        assert_eq!(resolver.strategy_count(), 0);
+    }
+
+    #[test]
+    fn test_remove_nonexistent_strategy() {
+        let mut resolver = IconResolver::new();
+        let removed = resolver.remove_strategy("nonexistent").unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_clear_strategies() {
+        let mut resolver = IconResolver::new();
+        
+        resolver.register_strategy(Box::new(MockStrategy::new("test1", 50, true))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("test2", 40, true))).unwrap();
+        
+        assert_eq!(resolver.strategy_count(), 2);
+        
+        resolver.clear().unwrap();
+        assert_eq!(resolver.strategy_count(), 0);
+    }
+
+    #[test]
+    fn test_statistics_tracking() {
+        let mut resolver = IconResolver::new();
+        
+        resolver.register_strategy(Box::new(MockStrategy::new("success", 90, true))).unwrap();
+        resolver.register_strategy(Box::new(MockStrategy::new("fail", 80, false))).unwrap();
+        
+        let context = IconContext::new("test-class".to_string());
+        
+        // Execute multiple times
+        for _ in 0..3 {
+            resolver.resolve(&context);
+        }
+        
+        let stats = resolver.get_stats().unwrap();
+        
+        // Success strategy should have been called once per resolution (first success wins)
+        assert_eq!(stats.get("success").unwrap().0, 3); // attempts
+        assert_eq!(stats.get("success").unwrap().1, 3); // successes
+        
+        // Fail strategy should never be called (success strategy wins first)
+        assert_eq!(stats.get("fail").unwrap().0, 0); // attempts
+        assert_eq!(stats.get("fail").unwrap().1, 0); // successes
+    }
+
+    // Mock provider for testing
+    struct MockProvider {
+        strategies: Vec<Box<dyn IconDetectionStrategy>>,
+    }
+
+    impl MockProvider {
+        fn new() -> Self {
+            Self {
+                strategies: vec![
+                    Box::new(MockStrategy::new("provider_strategy1", 60, true)),
+                    Box::new(MockStrategy::new("provider_strategy2", 40, false)),
+                ],
+            }
+        }
+    }
+
+    impl StrategyProvider for MockProvider {
+        fn get_strategies(&self) -> Vec<Box<dyn IconDetectionStrategy>> {
+            // Note: In a real implementation, we'd need to clone or recreate strategies
+            // For this test, we'll create new instances
+            vec![
+                Box::new(MockStrategy::new("provider_strategy1", 60, true)),
+                Box::new(MockStrategy::new("provider_strategy2", 40, false)),
+            ]
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "MockProvider"
+        }
+    }
+
+    #[test]
+    fn test_provider_registration() {
+        let mut resolver = IconResolver::new();
+        let provider = Box::new(MockProvider::new());
+        
+        resolver.register_provider(provider).unwrap();
+        
+        assert_eq!(resolver.strategy_count(), 2);
+        assert!(resolver.has_strategy("provider_strategy1"));
+        assert!(resolver.has_strategy("provider_strategy2"));
+    }
+}

--- a/src/icon/strategies/directory.rs
+++ b/src/icon/strategies/directory.rs
@@ -1,0 +1,674 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+use tracing::{debug, warn, error};
+
+use crate::icon::types::{IconContext, IconResult, IconMetadata, IconFormat};
+use crate::icon::traits::IconDetectionStrategy;
+
+/// Strategy that searches standard icon directories for icons
+/// 
+/// This strategy performs direct filesystem searches in standard icon directories
+/// like /usr/share/icons, /usr/share/pixmaps, ~/.local/share/icons, etc.
+/// It supports multiple icon formats (PNG, SVG, XPM) and implements caching
+/// to avoid repeated filesystem traversals.
+pub struct DirectoryStrategy {
+    /// Standard icon directories to search
+    search_directories: Vec<PathBuf>,
+    /// Cache of directory contents to avoid repeated filesystem scans
+    directory_cache: Arc<RwLock<HashMap<PathBuf, DirectoryCache>>>,
+    /// Cache TTL - how long directory cache entries remain valid
+    cache_ttl: Duration,
+    /// Supported icon formats in order of preference
+    supported_formats: Vec<IconFormat>,
+    /// Maximum recursion depth for directory traversal
+    max_depth: usize,
+}
+
+/// Cached directory information
+#[derive(Debug, Clone)]
+struct DirectoryCache {
+    /// Map of icon names (without extension) to full paths
+    icons: HashMap<String, Vec<PathBuf>>,
+    /// When this cache entry was created
+    created_at: Instant,
+    /// Whether this directory was successfully scanned
+    scan_successful: bool,
+}
+
+impl DirectoryCache {
+    fn new() -> Self {
+        Self {
+            icons: HashMap::new(),
+            created_at: Instant::now(),
+            scan_successful: false,
+        }
+    }
+
+    fn is_expired(&self, ttl: Duration) -> bool {
+        self.created_at.elapsed() > ttl
+    }
+}
+
+impl DirectoryStrategy {
+    /// Create a new DirectoryStrategy with default settings
+    pub fn new() -> Self {
+        Self {
+            search_directories: Self::default_search_directories(),
+            directory_cache: Arc::new(RwLock::new(HashMap::new())),
+            cache_ttl: Duration::from_secs(300), // 5 minutes
+            supported_formats: vec![
+                IconFormat::Svg,  // Prefer vector formats
+                IconFormat::Png,  // Then high-quality raster
+                IconFormat::Xpm,  // Legacy format
+            ],
+            max_depth: 4, // Reasonable depth to avoid infinite recursion
+        }
+    }
+
+    /// Create a DirectoryStrategy with custom directories
+    pub fn with_directories(directories: Vec<PathBuf>) -> Self {
+        let mut strategy = Self::new();
+        strategy.search_directories = directories;
+        strategy
+    }
+
+    /// Create a DirectoryStrategy with custom cache TTL
+    pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_ttl = ttl;
+        self
+    }
+
+    /// Create a DirectoryStrategy with custom max depth
+    pub fn with_max_depth(mut self, max_depth: usize) -> Self {
+        self.max_depth = max_depth;
+        self
+    }
+
+    /// Add additional search directories
+    pub fn add_directory(&mut self, directory: PathBuf) {
+        if !self.search_directories.contains(&directory) {
+            self.search_directories.push(directory);
+        }
+    }
+
+    /// Get the default icon search directories
+    fn default_search_directories() -> Vec<PathBuf> {
+        let mut directories = Vec::new();
+
+        // System-wide icon directories
+        directories.push(PathBuf::from("/usr/share/icons"));
+        directories.push(PathBuf::from("/usr/share/pixmaps"));
+        directories.push(PathBuf::from("/usr/local/share/icons"));
+        directories.push(PathBuf::from("/usr/local/share/pixmaps"));
+
+        // User-specific directories
+        if let Some(home) = std::env::var_os("HOME") {
+            let home_path = PathBuf::from(home);
+            directories.push(home_path.join(".local/share/icons"));
+            directories.push(home_path.join(".icons"));
+        }
+
+        // XDG data directories
+        if let Some(xdg_data_dirs) = std::env::var_os("XDG_DATA_DIRS") {
+            for dir in std::env::split_paths(&xdg_data_dirs) {
+                directories.push(dir.join("icons"));
+                directories.push(dir.join("pixmaps"));
+            }
+        }
+
+        // Flatpak directories
+        directories.push(PathBuf::from("/var/lib/flatpak/exports/share/icons"));
+        if let Some(home) = std::env::var_os("HOME") {
+            let home_path = PathBuf::from(home);
+            directories.push(home_path.join(".local/share/flatpak/exports/share/icons"));
+        }
+
+        // Filter to only existing directories
+        directories.into_iter()
+            .filter(|dir| dir.exists() && dir.is_dir())
+            .collect()
+    }
+
+    /// Search for an icon in all configured directories
+    fn search_icon(&self, icon_name: &str) -> Option<PathBuf> {
+        debug!("DirectoryStrategy: Searching for icon '{}'", icon_name);
+
+        for directory in &self.search_directories {
+            if let Some(path) = self.search_in_directory(directory, icon_name) {
+                debug!("DirectoryStrategy: Found icon '{}' at {:?}", icon_name, path);
+                return Some(path);
+            }
+        }
+
+        debug!("DirectoryStrategy: Icon '{}' not found in any directory", icon_name);
+        None
+    }
+
+    /// Search for an icon in a specific directory
+    fn search_in_directory(&self, directory: &Path, icon_name: &str) -> Option<PathBuf> {
+        // Check cache first
+        if let Some(cached_path) = self.check_cache(directory, icon_name) {
+            return Some(cached_path);
+        }
+
+        // If not in cache or cache is expired, scan the directory
+        self.scan_directory(directory);
+
+        // Check cache again after scanning
+        self.check_cache(directory, icon_name)
+    }
+
+    /// Check if an icon is in the directory cache
+    fn check_cache(&self, directory: &Path, icon_name: &str) -> Option<PathBuf> {
+        let cache = match self.directory_cache.read() {
+            Ok(cache) => cache,
+            Err(e) => {
+                error!("DirectoryStrategy: Failed to acquire cache read lock: {}", e);
+                return None;
+            }
+        };
+
+        if let Some(dir_cache) = cache.get(directory) {
+            if !dir_cache.is_expired(self.cache_ttl) && dir_cache.scan_successful {
+                if let Some(paths) = dir_cache.icons.get(icon_name) {
+                    // Return the first path with a preferred format
+                    for format in &self.supported_formats {
+                        for path in paths {
+                            if let Some(ext) = path.extension() {
+                                if let Some(ext_str) = ext.to_str() {
+                                    if IconFormat::from_extension(ext_str) == *format {
+                                        return Some(path.clone());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    // If no preferred format found, return the first available
+                    return paths.first().cloned();
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Scan a directory and update the cache
+    fn scan_directory(&self, directory: &Path) {
+        let mut cache = match self.directory_cache.write() {
+            Ok(cache) => cache,
+            Err(e) => {
+                error!("DirectoryStrategy: Failed to acquire cache write lock: {}", e);
+                return;
+            }
+        };
+
+        // Check if we need to scan (not in cache or expired)
+        let needs_scan = cache.get(directory)
+            .map(|dir_cache| dir_cache.is_expired(self.cache_ttl))
+            .unwrap_or(true);
+
+        if !needs_scan {
+            return;
+        }
+
+        debug!("DirectoryStrategy: Scanning directory {:?}", directory);
+
+        let mut dir_cache = DirectoryCache::new();
+        
+        match self.scan_directory_recursive(directory, 0, &mut dir_cache.icons) {
+            Ok(()) => {
+                dir_cache.scan_successful = true;
+                debug!("DirectoryStrategy: Successfully scanned {:?}, found {} icons", 
+                       directory, dir_cache.icons.len());
+                
+
+            }
+            Err(e) => {
+                warn!("DirectoryStrategy: Failed to scan directory {:?}: {}", directory, e);
+                dir_cache.scan_successful = false;
+            }
+        }
+
+        cache.insert(directory.to_path_buf(), dir_cache);
+    }
+
+    /// Recursively scan a directory for icon files
+    fn scan_directory_recursive(
+        &self,
+        directory: &Path,
+        current_depth: usize,
+        icons: &mut HashMap<String, Vec<PathBuf>>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if current_depth >= self.max_depth {
+            return Ok(());
+        }
+
+        let entries = fs::read_dir(directory)?;
+
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_dir() {
+                // Recursively scan subdirectories
+                if let Err(e) = self.scan_directory_recursive(&path, current_depth + 1, icons) {
+                    debug!("DirectoryStrategy: Failed to scan subdirectory {:?}: {}", path, e);
+                    // Continue with other directories even if one fails
+                }
+            } else if path.is_file() {
+                // Check if this is an icon file
+                if let Some(icon_name) = self.extract_icon_name(&path) {
+                    icons.entry(icon_name)
+                        .or_insert_with(Vec::new)
+                        .push(path);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract icon name from a file path if it's a supported icon format
+    fn extract_icon_name(&self, path: &Path) -> Option<String> {
+        let extension = path.extension()?.to_str()?;
+        let format = IconFormat::from_extension(extension);
+
+        // Check if this is a supported format
+        let is_supported = self.supported_formats.contains(&format) || 
+                          matches!(format, IconFormat::Other(_));
+
+        if is_supported {
+            path.file_stem()?.to_str().map(|s| s.to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Generate possible icon names from the context
+    fn generate_icon_names(&self, context: &IconContext) -> Vec<String> {
+        let mut names = Vec::new();
+
+        // Primary name: exact class name
+        names.push(context.class.clone());
+
+        // Lowercase version
+        let lowercase_class = context.class.to_lowercase();
+        if lowercase_class != context.class {
+            names.push(lowercase_class.clone());
+        }
+
+        // Replace common separators with hyphens
+        let hyphenated = lowercase_class.replace('_', "-").replace('.', "-");
+        if hyphenated != lowercase_class {
+            names.push(hyphenated);
+        }
+
+        // Try without common prefixes/suffixes
+        let cleaned = lowercase_class
+            .trim_start_matches("org.")
+            .trim_start_matches("com.")
+            .trim_start_matches("net.")
+            .trim_end_matches(".desktop")
+            .to_string();
+        if cleaned != lowercase_class && !names.contains(&cleaned) {
+            names.push(cleaned);
+        }
+
+        // If we have an executable name, try that too
+        if let Some(ref executable) = context.executable {
+            let exec_lower = executable.to_lowercase();
+            if !names.contains(&exec_lower) {
+                names.push(exec_lower);
+            }
+        }
+
+        // Try extracting application name from title if available
+        if let Some(ref title) = context.title {
+            // Common patterns: "AppName - Document", "Document - AppName", etc.
+            let title_lower = title.to_lowercase();
+            
+            // Try splitting on common separators and take the first/last part
+            for separator in &[" - ", " – ", " | ", ": "] {
+                if let Some(parts) = title_lower.split(separator).collect::<Vec<_>>().get(0) {
+                    let app_name = parts.trim().to_string();
+                    if !app_name.is_empty() && !names.contains(&app_name) {
+                        names.push(app_name);
+                    }
+                }
+            }
+        }
+
+        debug!("DirectoryStrategy: Generated icon names for '{}': {:?}", 
+               context.class, names);
+        names
+    }
+
+    /// Clear the directory cache
+    pub fn clear_cache(&self) {
+        if let Ok(mut cache) = self.directory_cache.write() {
+            cache.clear();
+            debug!("DirectoryStrategy: Cache cleared");
+        }
+    }
+
+    /// Get cache statistics
+    pub fn cache_stats(&self) -> Option<(usize, usize)> {
+        if let Ok(cache) = self.directory_cache.read() {
+            let total_entries = cache.len();
+            let expired_entries = cache.values()
+                .filter(|entry| entry.is_expired(self.cache_ttl))
+                .count();
+            Some((total_entries, expired_entries))
+        } else {
+            None
+        }
+    }
+}
+
+impl IconDetectionStrategy for DirectoryStrategy {
+    fn detect_icon(&self, context: &IconContext) -> Option<IconResult> {
+        let icon_names = self.generate_icon_names(context);
+
+        for icon_name in icon_names {
+            if let Some(path) = self.search_icon(&icon_name) {
+                // Determine the format from the file extension
+                let format = path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(IconFormat::from_extension)
+                    .unwrap_or(IconFormat::Other("unknown".to_string()));
+
+                let metadata = IconMetadata::new(format);
+
+                return Some(IconResult::new(
+                    path,
+                    "DirectoryStrategy".to_string(),
+                    0.7, // Medium confidence - we found a file but can't verify it's correct
+                    metadata,
+                ));
+            }
+        }
+
+        None
+    }
+
+    fn priority(&self) -> u8 {
+        25 // Medium-low priority - fallback after more specific strategies
+    }
+
+    fn name(&self) -> &'static str {
+        "DirectoryStrategy"
+    }
+
+    fn is_available(&self) -> bool {
+        // Available if we have at least one search directory
+        !self.search_directories.is_empty()
+    }
+
+    fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        debug!("DirectoryStrategy: Initializing with {} search directories", 
+               self.search_directories.len());
+        
+        for dir in &self.search_directories {
+            debug!("DirectoryStrategy: Will search in {:?}", dir);
+        }
+
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {
+        self.clear_cache();
+        debug!("DirectoryStrategy: Cleanup completed");
+    }
+}
+
+impl Default for DirectoryStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_test_icon_structure() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        let icons_dir = temp_dir.path().join("icons");
+        
+        // Create directory structure
+        fs::create_dir_all(&icons_dir).unwrap();
+        fs::create_dir_all(icons_dir.join("hicolor/48x48/apps")).unwrap();
+        fs::create_dir_all(icons_dir.join("Adwaita/scalable/apps")).unwrap();
+        
+        // Create test icon files
+        fs::write(icons_dir.join("firefox.png"), b"fake png").unwrap();
+        fs::write(icons_dir.join("chrome.svg"), b"fake svg").unwrap();
+        fs::write(icons_dir.join("hicolor/48x48/apps/gimp.png"), b"fake png").unwrap();
+        fs::write(icons_dir.join("Adwaita/scalable/apps/nautilus.svg"), b"fake svg").unwrap();
+        
+        temp_dir
+    }
+
+    #[test]
+    fn test_directory_strategy_creation() {
+        let strategy = DirectoryStrategy::new();
+        assert_eq!(strategy.name(), "DirectoryStrategy");
+        assert_eq!(strategy.priority(), 25);
+        assert!(strategy.is_available()); // Should have some default directories
+    }
+
+    #[test]
+    fn test_custom_directories() {
+        let custom_dirs = vec![PathBuf::from("/custom/path")];
+        let strategy = DirectoryStrategy::with_directories(custom_dirs.clone());
+        assert_eq!(strategy.search_directories, custom_dirs);
+    }
+
+    #[test]
+    fn test_icon_name_generation() {
+        let strategy = DirectoryStrategy::new();
+        
+        let context = IconContext::new("org.mozilla.Firefox".to_string())
+            .with_executable("firefox".to_string());
+        
+        let names = strategy.generate_icon_names(&context);
+        
+        assert!(names.contains(&"org.mozilla.Firefox".to_string()));
+        assert!(names.contains(&"org.mozilla.firefox".to_string()));
+        assert!(names.contains(&"org-mozilla-firefox".to_string()));
+        assert!(names.contains(&"mozilla.firefox".to_string()));
+        assert!(names.contains(&"firefox".to_string()));
+    }
+
+    #[test]
+    fn test_icon_name_from_title() {
+        let strategy = DirectoryStrategy::new();
+        
+        let context = IconContext::with_title("unknown".to_string(), "Firefox - Mozilla Firefox".to_string());
+        
+        let names = strategy.generate_icon_names(&context);
+        
+        assert!(names.contains(&"firefox".to_string()));
+    }
+
+    #[test]
+    fn test_extract_icon_name() {
+        let strategy = DirectoryStrategy::new();
+        
+        assert_eq!(
+            strategy.extract_icon_name(&PathBuf::from("/path/to/firefox.png")),
+            Some("firefox".to_string())
+        );
+        
+        assert_eq!(
+            strategy.extract_icon_name(&PathBuf::from("/path/to/app.svg")),
+            Some("app".to_string())
+        );
+        
+        // Unsupported format should still work (Other format)
+        assert_eq!(
+            strategy.extract_icon_name(&PathBuf::from("/path/to/app.ico")),
+            Some("app".to_string())
+        );
+        
+        // No extension
+        assert_eq!(
+            strategy.extract_icon_name(&PathBuf::from("/path/to/app")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_icon_detection_with_temp_directory() {
+        let temp_dir = create_test_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        let mut strategy = DirectoryStrategy::with_directories(vec![icons_path]);
+        strategy.initialize().unwrap();
+        
+        // Test finding a direct icon
+        let context = IconContext::new("firefox".to_string());
+        let result = strategy.detect_icon(&context);
+        assert!(result.is_some());
+        
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "DirectoryStrategy");
+        assert!(result.path.to_string_lossy().contains("firefox.png"));
+        
+        // Test finding an icon in subdirectory
+        let context = IconContext::new("gimp".to_string());
+        let result = strategy.detect_icon(&context);
+        assert!(result.is_some());
+        
+        // Test not finding an icon
+        let context = IconContext::new("nonexistent".to_string());
+        let result = strategy.detect_icon(&context);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_format_preference() {
+        let temp_dir = TempDir::new().unwrap();
+        let icons_dir = temp_dir.path().join("icons");
+        fs::create_dir_all(&icons_dir).unwrap();
+        
+        // Create same icon in different formats
+        fs::write(icons_dir.join("app.png"), b"fake png").unwrap();
+        fs::write(icons_dir.join("app.svg"), b"fake svg").unwrap();
+        fs::write(icons_dir.join("app.xpm"), b"fake xpm").unwrap();
+        
+        let mut strategy = DirectoryStrategy::with_directories(vec![icons_dir]);
+        strategy.initialize().unwrap();
+        
+        let context = IconContext::new("app".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        
+        // Should prefer SVG (vector format)
+        assert!(result.path.to_string_lossy().ends_with(".svg"));
+        assert!(matches!(result.metadata.format, IconFormat::Svg));
+    }
+
+    #[test]
+    fn test_cache_functionality() {
+        let temp_dir = create_test_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        let mut strategy = DirectoryStrategy::with_directories(vec![icons_path]);
+        strategy.initialize().unwrap();
+        
+        // First search should populate cache
+        let context = IconContext::new("firefox".to_string());
+        let result1 = strategy.detect_icon(&context);
+        assert!(result1.is_some());
+        
+        // Second search should use cache
+        let result2 = strategy.detect_icon(&context);
+        assert!(result2.is_some());
+        assert_eq!(result1.unwrap().path, result2.unwrap().path);
+        
+        // Check cache stats
+        let (total, expired) = strategy.cache_stats().unwrap();
+        assert!(total > 0);
+        assert_eq!(expired, 0); // Should not be expired immediately
+    }
+
+    #[test]
+    fn test_cache_expiration() {
+        let temp_dir = create_test_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        let mut strategy = DirectoryStrategy::with_directories(vec![icons_path])
+            .with_cache_ttl(Duration::from_millis(1)); // Very short TTL
+        strategy.initialize().unwrap();
+        
+        // First search
+        let context = IconContext::new("firefox".to_string());
+        strategy.detect_icon(&context);
+        
+        // Wait for cache to expire
+        std::thread::sleep(Duration::from_millis(10));
+        
+        // Check that cache entries are expired
+        let (total, expired) = strategy.cache_stats().unwrap();
+        assert!(total > 0);
+        assert!(expired > 0);
+    }
+
+    #[test]
+    fn test_max_depth_limiting() {
+        let temp_dir = TempDir::new().unwrap();
+        let base_dir = temp_dir.path().join("icons");
+        
+        // Create deep directory structure
+        let deep_dir = base_dir.join("level1/level2/level3/level4");
+        fs::create_dir_all(&deep_dir).unwrap();
+        fs::write(deep_dir.join("deep-icon.png"), b"fake png").unwrap();
+        
+        // Strategy with max depth 2 should not find the deep icon
+        let mut strategy = DirectoryStrategy::with_directories(vec![base_dir.clone()])
+            .with_max_depth(2);
+        strategy.initialize().unwrap();
+        
+        let context = IconContext::new("deep-icon".to_string());
+        let result = strategy.detect_icon(&context);
+        assert!(result.is_none());
+        
+        // Strategy with max depth 5 should find it
+        let mut strategy = DirectoryStrategy::with_directories(vec![base_dir])
+            .with_max_depth(5);
+        strategy.initialize().unwrap();
+        
+        let result = strategy.detect_icon(&context);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_cleanup() {
+        let temp_dir = create_test_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        let mut strategy = DirectoryStrategy::with_directories(vec![icons_path]);
+        strategy.initialize().unwrap();
+        
+        // Populate cache
+        let context = IconContext::new("firefox".to_string());
+        strategy.detect_icon(&context);
+        
+        let (total_before, _) = strategy.cache_stats().unwrap();
+        assert!(total_before > 0);
+        
+        // Cleanup should clear cache
+        strategy.cleanup();
+        
+        let (total_after, _) = strategy.cache_stats().unwrap();
+        assert_eq!(total_after, 0);
+    }
+}

--- a/src/icon/strategies/examples.rs
+++ b/src/icon/strategies/examples.rs
@@ -1,0 +1,253 @@
+/// Example usage of strategies with IconResolver
+/// 
+/// This module provides examples of how to integrate various strategies
+/// with the icon resolution system.
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+    use std::fs;
+    
+    use crate::icon::{IconResolver, IconContext};
+    use crate::icon::strategies::DirectoryStrategy;
+
+    fn create_example_icon_structure() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        let icons_dir = temp_dir.path().join("icons");
+        
+        // Create directory structure similar to real Linux systems
+        fs::create_dir_all(&icons_dir).unwrap();
+        fs::create_dir_all(icons_dir.join("hicolor/48x48/apps")).unwrap();
+        fs::create_dir_all(icons_dir.join("Adwaita/scalable/apps")).unwrap();
+        
+        // Create example icon files
+        fs::write(icons_dir.join("firefox.png"), b"fake firefox png").unwrap();
+        fs::write(icons_dir.join("chrome.svg"), b"fake chrome svg").unwrap();
+        fs::write(icons_dir.join("hicolor/48x48/apps/gimp.png"), b"fake gimp png").unwrap();
+        fs::write(icons_dir.join("Adwaita/scalable/apps/nautilus.svg"), b"fake nautilus svg").unwrap();
+        
+        temp_dir
+    }
+
+    #[test]
+    fn test_directory_strategy_integration() {
+        let temp_dir = create_example_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        // Create and configure the resolver
+        let mut resolver = IconResolver::new();
+        
+        // Create and register the DirectoryStrategy
+        let strategy = Box::new(DirectoryStrategy::with_directories(vec![icons_path]));
+        resolver.register_strategy(strategy).unwrap();
+        
+        // Test resolving various icons
+        let test_cases = vec![
+            ("firefox", true),
+            ("chrome", true),
+            ("gimp", true),
+            ("nautilus", true),
+            ("nonexistent", false),
+        ];
+        
+        for (class_name, should_find) in test_cases {
+            let context = IconContext::new(class_name.to_string());
+            let result = resolver.resolve(&context);
+            
+            if should_find {
+                assert!(result.is_some(), "Should find icon for {}", class_name);
+                let icon_result = result.unwrap();
+                assert_eq!(icon_result.strategy_used, "DirectoryStrategy");
+                assert!(icon_result.path.to_string_lossy().contains(class_name));
+            } else {
+                assert!(result.is_none(), "Should not find icon for {}", class_name);
+            }
+        }
+        
+        // Check resolver statistics
+        let stats = resolver.get_stats().unwrap();
+        let directory_stats = stats.get("DirectoryStrategy").unwrap();
+        assert_eq!(directory_stats.0, 5); // 5 attempts
+        assert_eq!(directory_stats.1, 4); // 4 successes
+    }
+
+    #[test]
+    fn test_directory_strategy_with_custom_config() {
+        let temp_dir = create_example_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        // Create a DirectoryStrategy with custom configuration
+        let strategy = DirectoryStrategy::with_directories(vec![icons_path])
+            .with_max_depth(5) // Allow deeper recursion
+            .with_cache_ttl(std::time::Duration::from_secs(600)); // 10 minute cache
+        
+        let mut resolver = IconResolver::new();
+        resolver.register_strategy(Box::new(strategy)).unwrap();
+        
+        // Test that it works with the custom configuration
+        let context = IconContext::new("gimp".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_some());
+        let icon_result = result.unwrap();
+        assert_eq!(icon_result.strategy_used, "DirectoryStrategy");
+        assert!(icon_result.path.to_string_lossy().contains("gimp"));
+    }
+
+    #[test]
+    fn test_directory_strategy_name_variations() {
+        let temp_dir = create_example_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        // Add an icon with a complex name
+        fs::write(icons_path.join("org.mozilla.firefox.png"), b"fake firefox png").unwrap();
+        
+        let mut resolver = IconResolver::new();
+        let strategy = Box::new(DirectoryStrategy::with_directories(vec![icons_path]));
+        resolver.register_strategy(strategy).unwrap();
+        
+        // Test that various name formats can find icons
+        // Some will find the complex name, others will find the simple "firefox" icon
+        let test_cases = vec![
+            ("org.mozilla.Firefox", true),
+            ("org.mozilla.firefox", true), 
+            ("mozilla.firefox", true),
+            ("firefox", true), // This should find the simple firefox.png
+        ];
+        
+        for (class_name, should_find) in test_cases {
+            let context = IconContext::new(class_name.to_string());
+            let result = resolver.resolve(&context);
+            
+            if should_find {
+                assert!(result.is_some(), "Should find icon for class: {}", class_name);
+                let icon_result = result.unwrap();
+                assert!(
+                    icon_result.path.to_string_lossy().contains("org.mozilla.firefox") ||
+                    icon_result.path.to_string_lossy().contains("firefox")
+                );
+            } else {
+                assert!(result.is_none(), "Should not find icon for class: {}", class_name);
+            }
+        }
+    }
+
+    #[test]
+    fn test_directory_strategy_format_preference() {
+        let temp_dir = TempDir::new().unwrap();
+        let icons_dir = temp_dir.path().join("icons");
+        fs::create_dir_all(&icons_dir).unwrap();
+        
+        // Create the same icon in multiple formats
+        fs::write(icons_dir.join("test-app.png"), b"fake png").unwrap();
+        fs::write(icons_dir.join("test-app.svg"), b"fake svg").unwrap();
+        fs::write(icons_dir.join("test-app.xpm"), b"fake xpm").unwrap();
+        
+        let mut resolver = IconResolver::new();
+        let strategy = Box::new(DirectoryStrategy::with_directories(vec![icons_dir]));
+        resolver.register_strategy(strategy).unwrap();
+        
+        let context = IconContext::new("test-app".to_string());
+        let result = resolver.resolve(&context);
+        
+        assert!(result.is_some());
+        let icon_result = result.unwrap();
+        
+        // Should prefer SVG (vector format) over raster formats
+        assert!(icon_result.path.to_string_lossy().ends_with(".svg"));
+    }
+
+    #[test]
+    fn test_hyprland_strategy_integration() {
+        use crate::icon::strategies::HyprlandStrategy;
+        
+        // Create a resolver with HyprlandStrategy
+        let mut resolver = IconResolver::new();
+        let strategy = Box::new(HyprlandStrategy::new());
+        resolver.register_strategy(strategy).unwrap();
+        
+        // Test with context that has Hyprland-specific information
+        let context = IconContext::with_title(
+            "unknown-class".to_string(), 
+            "Firefox - Mozilla Firefox".to_string()
+        );
+        
+        // The strategy should attempt to extract "Firefox" from the title
+        // and look for firefox icons (result depends on system icons)
+        let result = resolver.resolve(&context);
+        
+        // We can't guarantee the result since it depends on system icons,
+        // but we can verify the strategy was attempted
+        match result {
+            Some(icon_result) => {
+                assert_eq!(icon_result.strategy_used, "HyprlandStrategy");
+                assert_eq!(icon_result.confidence, 0.8);
+            }
+            None => {
+                // Expected if firefox icon doesn't exist on test system
+            }
+        }
+    }
+
+    #[test]
+    fn test_hyprland_strategy_with_executable() {
+        use crate::icon::strategies::HyprlandStrategy;
+        
+        let mut resolver = IconResolver::new();
+        let strategy = Box::new(HyprlandStrategy::new());
+        resolver.register_strategy(strategy).unwrap();
+        
+        // Test with executable information
+        let context = IconContext::new("unknown-class".to_string())
+            .with_executable("code".to_string());
+        
+        let result = resolver.resolve(&context);
+        
+        // Result depends on whether VS Code icon exists
+        match result {
+            Some(icon_result) => {
+                assert_eq!(icon_result.strategy_used, "HyprlandStrategy");
+            }
+            None => {
+                // Expected if code icon doesn't exist
+            }
+        }
+    }
+
+    #[test]
+    fn test_hyprland_strategy_priority() {
+        use crate::icon::strategies::{HyprlandStrategy, DirectoryStrategy};
+        
+        let temp_dir = create_example_icon_structure();
+        let icons_path = temp_dir.path().join("icons");
+        
+        // Create a firefox icon in the directory
+        fs::write(icons_path.join("firefox.png"), b"fake firefox png").unwrap();
+        
+        let mut resolver = IconResolver::new();
+        
+        // Register DirectoryStrategy with lower priority
+        let dir_strategy = Box::new(DirectoryStrategy::with_directories(vec![icons_path]));
+        resolver.register_strategy(dir_strategy).unwrap();
+        
+        // Register HyprlandStrategy with higher priority
+        let hypr_strategy = Box::new(HyprlandStrategy::new());
+        resolver.register_strategy(hypr_strategy).unwrap();
+        
+        // Test with context that both strategies could handle
+        let context = IconContext::with_title(
+            "firefox".to_string(),
+            "Firefox - Mozilla Firefox".to_string()
+        );
+        
+        let result = resolver.resolve(&context);
+        
+        if let Some(icon_result) = result {
+            // HyprlandStrategy should win due to higher priority (75 vs default)
+            // But only if it finds an icon, otherwise DirectoryStrategy will be used
+            assert!(icon_result.strategy_used == "HyprlandStrategy" || 
+                   icon_result.strategy_used == "DirectoryStrategy");
+        }
+    }
+}

--- a/src/icon/strategies/hyprland.rs
+++ b/src/icon/strategies/hyprland.rs
@@ -1,0 +1,510 @@
+use crate::icon::traits::IconDetectionStrategy;
+use crate::icon::types::{IconContext, IconResult, IconMetadata, IconFormat};
+use std::path::PathBuf;
+use std::process::Command;
+use std::collections::HashMap;
+use regex::Regex;
+use bevy::log::{debug, info};
+
+/// Strategy that uses enhanced Hyprland IPC information for icon detection
+/// 
+/// This strategy leverages additional information available from Hyprland IPC
+/// to improve icon detection by:
+/// 1. Parsing window titles to extract executable names
+/// 2. Using process information to map to icon names
+/// 3. Extracting application names from various title formats
+pub struct HyprlandStrategy {
+    /// Regex patterns for extracting executable names from window titles
+    title_patterns: Vec<TitlePattern>,
+    /// Cache for process ID to executable name mappings
+    pid_cache: HashMap<u32, String>,
+    /// Common application name mappings from titles
+    title_mappings: HashMap<String, String>,
+}
+
+/// Pattern for extracting information from window titles
+struct TitlePattern {
+    /// Regex pattern to match against titles
+    regex: Regex,
+    /// Group index that contains the executable/application name
+    name_group: usize,
+    /// Description of what this pattern matches
+    description: &'static str,
+}
+
+impl HyprlandStrategy {
+    /// Create a new HyprlandStrategy with default patterns
+    pub fn new() -> Self {
+        let mut strategy = Self {
+            title_patterns: Vec::new(),
+            pid_cache: HashMap::new(),
+            title_mappings: HashMap::new(),
+        };
+        
+        strategy.initialize_patterns();
+        strategy.initialize_mappings();
+        strategy
+    }
+
+    /// Initialize regex patterns for extracting names from window titles
+    fn initialize_patterns(&mut self) {
+        // Pattern for "AppName - Document" format (e.g., "Firefox - Mozilla Firefox")
+        if let Ok(regex) = Regex::new(r"^([^-]+)\s*-\s*.+$") {
+            self.title_patterns.push(TitlePattern {
+                regex,
+                name_group: 1,
+                description: "AppName - Document format",
+            });
+        }
+
+        // Pattern for "Document - AppName" format (e.g., "index.html - Visual Studio Code")
+        if let Ok(regex) = Regex::new(r"^.+\s*-\s*([^-]+)$") {
+            self.title_patterns.push(TitlePattern {
+                regex,
+                name_group: 1,
+                description: "Document - AppName format",
+            });
+        }
+
+        // Pattern for "[AppName]" format (e.g., "[Spotify]")
+        if let Ok(regex) = Regex::new(r"^\[([^\]]+)\]") {
+            self.title_patterns.push(TitlePattern {
+                regex,
+                name_group: 1,
+                description: "Bracketed app name format",
+            });
+        }
+
+        // Pattern for "AppName:" format (e.g., "Discord:")
+        if let Ok(regex) = Regex::new(r"^([^:]+):") {
+            self.title_patterns.push(TitlePattern {
+                regex,
+                name_group: 1,
+                description: "AppName: format",
+            });
+        }
+
+        // Pattern for executable in parentheses (e.g., "Window Title (firefox)")
+        if let Ok(regex) = Regex::new(r"\(([^)]+)\)$") {
+            self.title_patterns.push(TitlePattern {
+                regex,
+                name_group: 1,
+                description: "Executable in parentheses",
+            });
+        }
+
+        // Pattern for version numbers (e.g., "Firefox 120.0")
+        if let Ok(regex) = Regex::new(r"^([A-Za-z]+)\s+\d+") {
+            self.title_patterns.push(TitlePattern {
+                regex,
+                name_group: 1,
+                description: "AppName with version",
+            });
+        }
+    }
+
+    /// Initialize common title to application name mappings
+    fn initialize_mappings(&mut self) {
+        // Common application title variations
+        self.title_mappings.insert("Mozilla Firefox".to_string(), "firefox".to_string());
+        self.title_mappings.insert("Firefox".to_string(), "firefox".to_string());
+        self.title_mappings.insert("Google Chrome".to_string(), "google-chrome".to_string());
+        self.title_mappings.insert("Chrome".to_string(), "google-chrome".to_string());
+        self.title_mappings.insert("Chromium".to_string(), "chromium".to_string());
+        self.title_mappings.insert("Visual Studio Code".to_string(), "code".to_string());
+        self.title_mappings.insert("VS Code".to_string(), "code".to_string());
+        self.title_mappings.insert("Code".to_string(), "code".to_string());
+        self.title_mappings.insert("Spotify".to_string(), "spotify".to_string());
+        self.title_mappings.insert("Discord".to_string(), "discord".to_string());
+        self.title_mappings.insert("Telegram".to_string(), "telegram".to_string());
+        self.title_mappings.insert("WhatsApp".to_string(), "whatsapp".to_string());
+        self.title_mappings.insert("Slack".to_string(), "slack".to_string());
+        self.title_mappings.insert("GIMP".to_string(), "gimp".to_string());
+        self.title_mappings.insert("LibreOffice".to_string(), "libreoffice".to_string());
+        self.title_mappings.insert("Thunderbird".to_string(), "thunderbird".to_string());
+        self.title_mappings.insert("VLC".to_string(), "vlc".to_string());
+        self.title_mappings.insert("Nautilus".to_string(), "nautilus".to_string());
+        self.title_mappings.insert("Files".to_string(), "nautilus".to_string());
+        self.title_mappings.insert("Terminal".to_string(), "gnome-terminal".to_string());
+        self.title_mappings.insert("Konsole".to_string(), "konsole".to_string());
+        self.title_mappings.insert("Alacritty".to_string(), "alacritty".to_string());
+        self.title_mappings.insert("Kitty".to_string(), "kitty".to_string());
+    }
+
+    /// Extract potential application names from window title
+    fn extract_names_from_title(&self, title: &str) -> Vec<String> {
+        let mut names = Vec::new();
+        
+        debug!("Extracting names from title: '{}'", title);
+
+        // First, check direct mappings
+        if let Some(mapped_name) = self.title_mappings.get(title) {
+            names.push(mapped_name.clone());
+            debug!("Found direct mapping: '{}' -> '{}'", title, mapped_name);
+        }
+
+        // Try each regex pattern
+        for pattern in &self.title_patterns {
+            if let Some(captures) = pattern.regex.captures(title) {
+                if let Some(matched) = captures.get(pattern.name_group) {
+                    let extracted = matched.as_str().trim().to_string();
+                    if !extracted.is_empty() && !names.contains(&extracted) {
+                        names.push(extracted.clone());
+                        debug!("Pattern '{}' extracted: '{}'", pattern.description, extracted);
+                        
+                        // Also try lowercase version
+                        let lowercase = extracted.to_lowercase();
+                        if !names.contains(&lowercase) {
+                            names.push(lowercase);
+                        }
+
+                        // Check if extracted name has a mapping
+                        if let Some(mapped) = self.title_mappings.get(&extracted) {
+                            if !names.contains(mapped) {
+                                names.push(mapped.clone());
+                                debug!("Mapped extracted name: '{}' -> '{}'", extracted, mapped);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Split title by common separators and try each part
+        for separator in &[" - ", " | ", " :: ", " — "] {
+            if title.contains(separator) {
+                for part in title.split(separator) {
+                    let trimmed = part.trim();
+                    if !trimmed.is_empty() && trimmed.len() > 2 {
+                        // Check if this part has a mapping
+                        if let Some(mapped) = self.title_mappings.get(trimmed) {
+                            if !names.contains(mapped) {
+                                names.push(mapped.clone());
+                                debug!("Found mapping for title part: '{}' -> '{}'", trimmed, mapped);
+                            }
+                        }
+                        
+                        // Add the part itself (lowercase)
+                        let lowercase_part = trimmed.to_lowercase();
+                        if !names.contains(&lowercase_part) {
+                            names.push(lowercase_part);
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!("Extracted {} names from title: {:?}", names.len(), names);
+        names
+    }
+
+    /// Get executable name from process ID using /proc filesystem
+    fn get_executable_from_pid(&mut self, pid: u32) -> Option<String> {
+        // Check cache first
+        if let Some(cached) = self.pid_cache.get(&pid) {
+            return Some(cached.clone());
+        }
+
+        // Try to read from /proc/PID/comm (process name)
+        let comm_path = format!("/proc/{}/comm", pid);
+        if let Ok(comm) = std::fs::read_to_string(&comm_path) {
+            let executable = comm.trim().to_string();
+            if !executable.is_empty() {
+                debug!("Found executable from /proc/{}/comm: '{}'", pid, executable);
+                self.pid_cache.insert(pid, executable.clone());
+                return Some(executable);
+            }
+        }
+
+        // Try to read from /proc/PID/cmdline (command line)
+        let cmdline_path = format!("/proc/{}/cmdline", pid);
+        if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
+            // cmdline is null-separated, take the first part (executable path)
+            if let Some(first_arg) = cmdline.split('\0').next() {
+                if let Some(executable) = std::path::Path::new(first_arg).file_name() {
+                    if let Some(name) = executable.to_str() {
+                        let name = name.to_string();
+                        debug!("Found executable from /proc/{}/cmdline: '{}'", pid, name);
+                        self.pid_cache.insert(pid, name.clone());
+                        return Some(name);
+                    }
+                }
+            }
+        }
+
+        // Try using ps command as fallback
+        if let Ok(output) = Command::new("ps")
+            .args(&["-p", &pid.to_string(), "-o", "comm="])
+            .output()
+        {
+            if output.status.success() {
+                let comm = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !comm.is_empty() {
+                    debug!("Found executable from ps command: '{}'", comm);
+                    self.pid_cache.insert(pid, comm.clone());
+                    return Some(comm);
+                }
+            }
+        }
+
+        debug!("Could not determine executable for PID {}", pid);
+        None
+    }
+
+    /// Try to find icon using Hyprland-specific information
+    fn find_icon_with_hyprland_info(&mut self, context: &IconContext) -> Option<IconResult> {
+        let mut candidate_names = Vec::new();
+
+        // If we have a PID, try to get the executable name
+        if let Some(pid) = context.pid {
+            if let Some(executable) = self.get_executable_from_pid(pid) {
+                candidate_names.push(executable.clone());
+                candidate_names.push(executable.to_lowercase());
+                debug!("Added executable from PID {}: '{}'", pid, executable);
+            }
+        }
+
+        // If we have a title, extract potential names from it
+        if let Some(ref title) = context.title {
+            let title_names = self.extract_names_from_title(title);
+            for name in title_names {
+                if !candidate_names.contains(&name) {
+                    candidate_names.push(name);
+                }
+            }
+        }
+
+        // Try to find icons for each candidate name
+        for name in &candidate_names {
+            if let Some(icon_path) = self.find_icon_for_name(name) {
+                let format = IconFormat::from_extension(
+                    icon_path.extension()
+                        .and_then(|ext| ext.to_str())
+                        .unwrap_or("png")
+                );
+                
+                let metadata = IconMetadata::new(format);
+                
+                info!("HyprlandStrategy found icon for '{}': {:?}", name, icon_path);
+                
+                return Some(IconResult::new(
+                    icon_path,
+                    "HyprlandStrategy".to_string(),
+                    0.8, // High confidence since we used Hyprland-specific info
+                    metadata,
+                ));
+            }
+        }
+
+        debug!("HyprlandStrategy could not find icon for any candidate names: {:?}", candidate_names);
+        None
+    }
+
+    /// Find icon file for a given application name
+    fn find_icon_for_name(&self, name: &str) -> Option<PathBuf> {
+        // Standard icon directories to search
+        let icon_dirs = [
+            "/usr/share/icons/hicolor/48x48/apps",
+            "/usr/share/icons/hicolor/scalable/apps",
+            "/usr/share/pixmaps",
+            "/usr/share/icons",
+            "/usr/local/share/icons",
+        ];
+
+        // Icon file extensions to try
+        let extensions = ["svg", "png", "xpm"];
+
+        for dir in &icon_dirs {
+            for ext in &extensions {
+                let icon_path = PathBuf::from(dir).join(format!("{}.{}", name, ext));
+                if icon_path.exists() {
+                    debug!("Found icon at: {:?}", icon_path);
+                    return Some(icon_path);
+                }
+            }
+        }
+
+        // Try with common variations
+        let variations = [
+            format!("{}-icon", name),
+            format!("application-{}", name),
+            format!("{}_icon", name),
+            name.replace("-", "_"),
+            name.replace("_", "-"),
+        ];
+
+        for dir in &icon_dirs {
+            for variation in &variations {
+                for ext in &extensions {
+                    let icon_path = PathBuf::from(dir).join(format!("{}.{}", variation, ext));
+                    if icon_path.exists() {
+                        debug!("Found icon with variation '{}' at: {:?}", variation, icon_path);
+                        return Some(icon_path);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl Default for HyprlandStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IconDetectionStrategy for HyprlandStrategy {
+    fn detect_icon(&self, context: &IconContext) -> Option<IconResult> {
+        debug!("HyprlandStrategy attempting detection for context: {:?}", context);
+
+        // Create a mutable copy to work with caches
+        let mut strategy = HyprlandStrategy {
+            title_patterns: self.title_patterns.clone(),
+            pid_cache: self.pid_cache.clone(),
+            title_mappings: self.title_mappings.clone(),
+        };
+
+        // Only proceed if we have additional Hyprland information beyond just the class
+        let has_hyprland_info = context.title.is_some() || 
+                               context.pid.is_some() || 
+                               context.executable.is_some();
+
+        if !has_hyprland_info {
+            debug!("HyprlandStrategy skipping - no additional Hyprland info available");
+            return None;
+        }
+
+        strategy.find_icon_with_hyprland_info(context)
+    }
+
+    fn priority(&self) -> u8 {
+        75 // High priority since this uses Hyprland-specific information
+    }
+
+    fn name(&self) -> &'static str {
+        "HyprlandStrategy"
+    }
+
+    fn is_available(&self) -> bool {
+        // Check if we're running under Hyprland
+        std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok()
+    }
+}
+
+// Helper trait to make TitlePattern cloneable
+impl Clone for TitlePattern {
+    fn clone(&self) -> Self {
+        Self {
+            regex: Regex::new(self.regex.as_str()).unwrap(),
+            name_group: self.name_group,
+            description: self.description,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::icon::types::IconContext;
+
+    #[test]
+    fn test_extract_names_from_title() {
+        let strategy = HyprlandStrategy::new();
+
+        // Test "AppName - Document" format
+        let names = strategy.extract_names_from_title("Firefox - Mozilla Firefox");
+        assert!(names.contains(&"firefox".to_string()));
+
+        // Test direct mapping
+        let names = strategy.extract_names_from_title("Visual Studio Code");
+        assert!(names.contains(&"code".to_string()));
+
+        // Test bracketed format
+        let names = strategy.extract_names_from_title("[Spotify] - Song Name");
+        assert!(names.contains(&"spotify".to_string()));
+
+        // Test version format
+        let names = strategy.extract_names_from_title("Firefox 120.0");
+        assert!(names.contains(&"firefox".to_string()));
+    }
+
+    #[test]
+    fn test_title_mappings() {
+        let strategy = HyprlandStrategy::new();
+        
+        // Test that common applications are mapped correctly
+        assert_eq!(strategy.title_mappings.get("Mozilla Firefox"), Some(&"firefox".to_string()));
+        assert_eq!(strategy.title_mappings.get("Visual Studio Code"), Some(&"code".to_string()));
+        assert_eq!(strategy.title_mappings.get("Google Chrome"), Some(&"google-chrome".to_string()));
+    }
+
+    #[test]
+    fn test_strategy_priority() {
+        let strategy = HyprlandStrategy::new();
+        assert_eq!(strategy.priority(), 75);
+    }
+
+    #[test]
+    fn test_strategy_name() {
+        let strategy = HyprlandStrategy::new();
+        assert_eq!(strategy.name(), "HyprlandStrategy");
+    }
+
+    #[test]
+    fn test_detect_icon_with_title() {
+        let strategy = HyprlandStrategy::new();
+        
+        let context = IconContext::with_title("unknown-class".to_string(), "Firefox - Mozilla Firefox".to_string());
+        
+        // This test will only pass if Firefox icon actually exists on the system
+        // In a real test environment, we might want to mock the file system
+        let result = strategy.detect_icon(&context);
+        
+        // We can at least verify that the strategy processes the context
+        // without panicking and returns the expected type
+        match result {
+            Some(icon_result) => {
+                assert_eq!(icon_result.strategy_used, "HyprlandStrategy");
+                assert_eq!(icon_result.confidence, 0.8);
+            }
+            None => {
+                // This is expected if the icon doesn't exist on the test system
+            }
+        }
+    }
+
+    #[test]
+    fn test_detect_icon_without_hyprland_info() {
+        let strategy = HyprlandStrategy::new();
+        
+        // Context with only class (no Hyprland-specific info)
+        let context = IconContext::new("firefox".to_string());
+        
+        // Should return None since there's no additional Hyprland info
+        let result = strategy.detect_icon(&context);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_detect_icon_with_executable() {
+        let strategy = HyprlandStrategy::new();
+        
+        let context = IconContext::new("unknown-class".to_string())
+            .with_executable("firefox".to_string());
+        
+        // Should attempt detection since we have executable info
+        let result = strategy.detect_icon(&context);
+        
+        // Result depends on whether icon exists, but should not panic
+        match result {
+            Some(icon_result) => {
+                assert_eq!(icon_result.strategy_used, "HyprlandStrategy");
+            }
+            None => {
+                // Expected if icon doesn't exist
+            }
+        }
+    }
+}

--- a/src/icon/strategies/mapping.rs
+++ b/src/icon/strategies/mapping.rs
@@ -1,0 +1,988 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use tracing::{debug, warn};
+
+use crate::icon::types::{IconContext, IconResult, IconMetadata, IconFormat};
+use crate::icon::traits::IconDetectionStrategy;
+
+/// Component that manages application class to icon name mappings
+/// 
+/// This component handles the mapping of window class names to appropriate icon names.
+/// It supports multiple aliases per application and can be configured with custom mappings.
+#[derive(Debug, Clone)]
+pub struct ApplicationMapper {
+    /// Map from window class to possible icon names (in order of preference)
+    class_mappings: HashMap<String, Vec<String>>,
+    /// Reverse mapping from icon name to preferred class (for optimization)
+    reverse_mappings: HashMap<String, String>,
+}
+
+impl ApplicationMapper {
+    /// Create a new ApplicationMapper with default mappings
+    pub fn new() -> Self {
+        let mut mapper = Self {
+            class_mappings: HashMap::new(),
+            reverse_mappings: HashMap::new(),
+        };
+        
+        mapper.load_default_mappings();
+        mapper
+    }
+
+    /// Create an ApplicationMapper with custom mappings only
+    pub fn with_custom_mappings(mappings: HashMap<String, Vec<String>>) -> Self {
+        let mut mapper = Self {
+            class_mappings: HashMap::new(),
+            reverse_mappings: HashMap::new(),
+        };
+        
+        for (class, aliases) in mappings {
+            mapper.add_mapping(class, aliases);
+        }
+        
+        mapper
+    }
+
+    /// Add a mapping from window class to icon names
+    /// 
+    /// # Arguments
+    /// * `class` - The window class name
+    /// * `icon_names` - List of possible icon names in order of preference
+    pub fn add_mapping(&mut self, class: String, icon_names: Vec<String>) {
+        if icon_names.is_empty() {
+            warn!("ApplicationMapper: Empty icon names list for class '{}'", class);
+            return;
+        }
+
+        // Add reverse mapping for the first (preferred) icon name
+        if let Some(first_icon) = icon_names.first() {
+            self.reverse_mappings.insert(first_icon.clone(), class.clone());
+        }
+
+        self.class_mappings.insert(class, icon_names);
+    }
+
+    /// Add a single alias for a window class
+    pub fn add_alias(&mut self, class: String, icon_name: String) {
+        self.class_mappings
+            .entry(class)
+            .or_insert_with(Vec::new)
+            .push(icon_name);
+    }
+
+    /// Get possible icon names for a window class
+    pub fn get_icon_names(&self, class: &str) -> Option<&Vec<String>> {
+        // Try exact match first
+        if let Some(names) = self.class_mappings.get(class) {
+            return Some(names);
+        }
+
+        // Try case-insensitive match
+        let class_lower = class.to_lowercase();
+        for (mapped_class, names) in &self.class_mappings {
+            if mapped_class.to_lowercase() == class_lower {
+                return Some(names);
+            }
+        }
+
+        None
+    }
+
+    /// Get the preferred class name for an icon name (reverse lookup)
+    pub fn get_preferred_class(&self, icon_name: &str) -> Option<&String> {
+        self.reverse_mappings.get(icon_name)
+    }
+
+    /// Check if a class has any mappings
+    pub fn has_mapping(&self, class: &str) -> bool {
+        self.get_icon_names(class).is_some()
+    }
+
+    /// Get all mapped classes
+    pub fn get_all_classes(&self) -> Vec<&String> {
+        self.class_mappings.keys().collect()
+    }
+
+    /// Get the number of mappings
+    pub fn mapping_count(&self) -> usize {
+        self.class_mappings.len()
+    }
+
+    /// Load default mappings for common applications
+    fn load_default_mappings(&mut self) {
+        // Web browsers
+        self.add_mapping("firefox".to_string(), vec![
+            "firefox".to_string(),
+            "Firefox".to_string(),
+            "mozilla-firefox".to_string(),
+        ]);
+        
+        self.add_mapping("Google-chrome".to_string(), vec![
+            "google-chrome".to_string(),
+            "chrome".to_string(),
+            "chromium".to_string(),
+        ]);
+        
+        self.add_mapping("chromium-browser".to_string(), vec![
+            "chromium".to_string(),
+            "chromium-browser".to_string(),
+            "chrome".to_string(),
+        ]);
+        
+        self.add_mapping("brave-browser".to_string(), vec![
+            "brave".to_string(),
+            "brave-browser".to_string(),
+        ]);
+
+        // Text editors and IDEs
+        self.add_mapping("code".to_string(), vec![
+            "vscode".to_string(),
+            "code".to_string(),
+            "visual-studio-code".to_string(),
+        ]);
+        
+        self.add_mapping("Code".to_string(), vec![
+            "vscode".to_string(),
+            "code".to_string(),
+            "visual-studio-code".to_string(),
+        ]);
+        
+        self.add_mapping("nvim".to_string(), vec![
+            "nvim".to_string(),
+            "neovim".to_string(),
+            "vim".to_string(),
+        ]);
+        
+        self.add_mapping("emacs".to_string(), vec![
+            "emacs".to_string(),
+            "gnu-emacs".to_string(),
+        ]);
+
+        // Terminals
+        self.add_mapping("Alacritty".to_string(), vec![
+            "alacritty".to_string(),
+            "terminal".to_string(),
+        ]);
+        
+        self.add_mapping("kitty".to_string(), vec![
+            "kitty".to_string(),
+            "terminal".to_string(),
+        ]);
+        
+        self.add_mapping("gnome-terminal".to_string(), vec![
+            "gnome-terminal".to_string(),
+            "terminal".to_string(),
+        ]);
+        
+        self.add_mapping("konsole".to_string(), vec![
+            "konsole".to_string(),
+            "terminal".to_string(),
+        ]);
+
+        // File managers
+        self.add_mapping("nautilus".to_string(), vec![
+            "nautilus".to_string(),
+            "file-manager".to_string(),
+            "folder".to_string(),
+        ]);
+        
+        self.add_mapping("dolphin".to_string(), vec![
+            "dolphin".to_string(),
+            "file-manager".to_string(),
+            "folder".to_string(),
+        ]);
+        
+        self.add_mapping("thunar".to_string(), vec![
+            "thunar".to_string(),
+            "file-manager".to_string(),
+            "folder".to_string(),
+        ]);
+
+        // Media applications
+        self.add_mapping("vlc".to_string(), vec![
+            "vlc".to_string(),
+            "vlc-media-player".to_string(),
+        ]);
+        
+        self.add_mapping("mpv".to_string(), vec![
+            "mpv".to_string(),
+            "video-player".to_string(),
+        ]);
+        
+        self.add_mapping("spotify".to_string(), vec![
+            "spotify".to_string(),
+            "audio-player".to_string(),
+        ]);
+
+        // Communication
+        self.add_mapping("discord".to_string(), vec![
+            "discord".to_string(),
+            "chat".to_string(),
+        ]);
+        
+        self.add_mapping("slack".to_string(), vec![
+            "slack".to_string(),
+            "chat".to_string(),
+        ]);
+        
+        self.add_mapping("telegram-desktop".to_string(), vec![
+            "telegram".to_string(),
+            "telegram-desktop".to_string(),
+        ]);
+
+        // Development tools
+        self.add_mapping("jetbrains-idea".to_string(), vec![
+            "intellij-idea".to_string(),
+            "idea".to_string(),
+            "jetbrains-idea".to_string(),
+        ]);
+        
+        self.add_mapping("jetbrains-pycharm".to_string(), vec![
+            "pycharm".to_string(),
+            "jetbrains-pycharm".to_string(),
+        ]);
+        
+        self.add_mapping("DBeaver".to_string(), vec![
+            "dbeaver".to_string(),
+            "database".to_string(),
+        ]);
+
+        // Graphics and design
+        self.add_mapping("gimp".to_string(), vec![
+            "gimp".to_string(),
+            "gnu-image-manipulation-program".to_string(),
+        ]);
+        
+        self.add_mapping("inkscape".to_string(), vec![
+            "inkscape".to_string(),
+            "vector-graphics".to_string(),
+        ]);
+        
+        self.add_mapping("blender".to_string(), vec![
+            "blender".to_string(),
+            "3d-graphics".to_string(),
+        ]);
+
+        // Office applications
+        self.add_mapping("libreoffice-writer".to_string(), vec![
+            "libreoffice-writer".to_string(),
+            "writer".to_string(),
+            "text-editor".to_string(),
+        ]);
+        
+        self.add_mapping("libreoffice-calc".to_string(), vec![
+            "libreoffice-calc".to_string(),
+            "calc".to_string(),
+            "spreadsheet".to_string(),
+        ]);
+
+        // System applications
+        self.add_mapping("gnome-system-monitor".to_string(), vec![
+            "gnome-system-monitor".to_string(),
+            "system-monitor".to_string(),
+            "task-manager".to_string(),
+        ]);
+        
+        self.add_mapping("htop".to_string(), vec![
+            "htop".to_string(),
+            "system-monitor".to_string(),
+            "task-manager".to_string(),
+        ]);
+
+        debug!("ApplicationMapper: Loaded {} default mappings", self.mapping_count());
+    }
+
+    /// Merge another mapper's mappings into this one
+    pub fn merge(&mut self, other: &ApplicationMapper) {
+        for (class, icon_names) in &other.class_mappings {
+            // If we already have this class, extend the icon names
+            if let Some(existing_names) = self.class_mappings.get_mut(class) {
+                for name in icon_names {
+                    if !existing_names.contains(name) {
+                        existing_names.push(name.clone());
+                    }
+                }
+            } else {
+                // Add new mapping
+                self.add_mapping(class.clone(), icon_names.clone());
+            }
+        }
+    }
+
+    /// Clear all mappings
+    pub fn clear(&mut self) {
+        self.class_mappings.clear();
+        self.reverse_mappings.clear();
+    }
+}
+
+impl Default for ApplicationMapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Strategy that uses application mappings to find appropriate icon names
+/// 
+/// This strategy consults a configurable mapping of window classes to icon names.
+/// It's particularly useful for applications that have non-standard class names
+/// or need specific icon mappings.
+pub struct MappingStrategy {
+    /// The application mapper containing class-to-icon mappings
+    mapper: Arc<RwLock<ApplicationMapper>>,
+    /// Whether to use fuzzy matching for class names
+    fuzzy_matching: bool,
+}
+
+impl MappingStrategy {
+    /// Create a new MappingStrategy with default mappings
+    pub fn new() -> Self {
+        Self {
+            mapper: Arc::new(RwLock::new(ApplicationMapper::new())),
+            fuzzy_matching: true,
+        }
+    }
+
+    /// Create a MappingStrategy with a custom mapper
+    pub fn with_mapper(mapper: ApplicationMapper) -> Self {
+        Self {
+            mapper: Arc::new(RwLock::new(mapper)),
+            fuzzy_matching: true,
+        }
+    }
+
+    /// Create a MappingStrategy with custom mappings
+    pub fn with_mappings(mappings: HashMap<String, Vec<String>>) -> Self {
+        Self {
+            mapper: Arc::new(RwLock::new(ApplicationMapper::with_custom_mappings(mappings))),
+            fuzzy_matching: true,
+        }
+    }
+
+    /// Enable or disable fuzzy matching
+    pub fn with_fuzzy_matching(mut self, enabled: bool) -> Self {
+        self.fuzzy_matching = enabled;
+        self
+    }
+
+    /// Add a mapping to the strategy
+    pub fn add_mapping(&self, class: String, icon_names: Vec<String>) -> Result<(), String> {
+        match self.mapper.write() {
+            Ok(mut mapper) => {
+                mapper.add_mapping(class, icon_names);
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to acquire write lock: {}", e)),
+        }
+    }
+
+    /// Add an alias for a class
+    pub fn add_alias(&self, class: String, icon_name: String) -> Result<(), String> {
+        match self.mapper.write() {
+            Ok(mut mapper) => {
+                mapper.add_alias(class, icon_name);
+                Ok(())
+            }
+            Err(e) => Err(format!("Failed to acquire write lock: {}", e)),
+        }
+    }
+
+    /// Get the current mapper (read-only access)
+    pub fn get_mapper(&self) -> Result<std::sync::RwLockReadGuard<ApplicationMapper>, String> {
+        self.mapper.read().map_err(|e| format!("Failed to acquire read lock: {}", e))
+    }
+
+    /// Try to find icon names using fuzzy matching
+    fn fuzzy_match_class(&self, mapper: &ApplicationMapper, class: &str) -> Option<Vec<String>> {
+        if !self.fuzzy_matching {
+            return None;
+        }
+
+        let class_lower = class.to_lowercase();
+        
+        // Try partial matches
+        for (mapped_class, icon_names) in mapper.class_mappings.iter() {
+            let mapped_lower = mapped_class.to_lowercase();
+            
+            // Check if the class contains the mapped class or vice versa
+            if class_lower.contains(&mapped_lower) || mapped_lower.contains(&class_lower) {
+                debug!("MappingStrategy: Fuzzy match '{}' -> '{}' -> {:?}", 
+                       class, mapped_class, icon_names);
+                return Some(icon_names.clone());
+            }
+        }
+
+        // Try matching without common prefixes/suffixes
+        let cleaned_class = class_lower
+            .trim_start_matches("org.")
+            .trim_start_matches("com.")
+            .trim_start_matches("net.")
+            .trim_end_matches(".desktop")
+            .replace('-', "")
+            .replace('_', "")
+            .replace('.', "");
+
+        for (mapped_class, icon_names) in mapper.class_mappings.iter() {
+            let cleaned_mapped = mapped_class.to_lowercase()
+                .replace('-', "")
+                .replace('_', "")
+                .replace('.', "");
+            
+            if cleaned_class == cleaned_mapped {
+                debug!("MappingStrategy: Cleaned fuzzy match '{}' -> '{}' -> {:?}", 
+                       class, mapped_class, icon_names);
+                return Some(icon_names.clone());
+            }
+        }
+
+        None
+    }
+
+    /// Generate additional icon names from context
+    fn generate_context_names(&self, context: &IconContext) -> Vec<String> {
+        let mut names = Vec::new();
+
+        // Use executable name if available
+        if let Some(ref executable) = context.executable {
+            names.push(executable.clone());
+            names.push(executable.to_lowercase());
+        }
+
+        // Extract potential application names from title
+        if let Some(ref title) = context.title {
+            // Common patterns in window titles
+            let title_lower = title.to_lowercase();
+            
+            // Try splitting on common separators
+            for separator in &[" - ", " – ", " | ", ": ", " ("] {
+                if let Some(app_part) = title_lower.split(separator).next() {
+                    let app_name = app_part.trim().to_string();
+                    if !app_name.is_empty() && app_name.len() > 2 {
+                        names.push(app_name);
+                    }
+                }
+            }
+        }
+
+        names
+    }
+}
+
+impl IconDetectionStrategy for MappingStrategy {
+    fn detect_icon(&self, context: &IconContext) -> Option<IconResult> {
+        let mapper = match self.mapper.read() {
+            Ok(mapper) => mapper,
+            Err(e) => {
+                warn!("MappingStrategy: Failed to acquire read lock: {}", e);
+                return None;
+            }
+        };
+
+        debug!("MappingStrategy: Looking for mappings for class '{}'", context.class);
+
+        // Try exact mapping first
+        if let Some(icon_names) = mapper.get_icon_names(&context.class) {
+            debug!("MappingStrategy: Found exact mapping for '{}': {:?}", 
+                   context.class, icon_names);
+            
+            // Return the first icon name as a result
+            // The actual icon file resolution will be handled by other strategies
+            if let Some(first_name) = icon_names.first() {
+                let metadata = IconMetadata::new(IconFormat::Other("mapped".to_string()));
+                
+                return Some(IconResult::new(
+                    std::path::PathBuf::from(first_name), // This will be resolved by other strategies
+                    "MappingStrategy".to_string(),
+                    0.9, // High confidence - we have an explicit mapping
+                    metadata,
+                ));
+            }
+        }
+
+        // Try fuzzy matching
+        if let Some(icon_names) = self.fuzzy_match_class(&mapper, &context.class) {
+            if let Some(first_name) = icon_names.first() {
+                let metadata = IconMetadata::new(IconFormat::Other("mapped".to_string()));
+                
+                return Some(IconResult::new(
+                    std::path::PathBuf::from(first_name),
+                    "MappingStrategy".to_string(),
+                    0.7, // Medium-high confidence - fuzzy match
+                    metadata,
+                ));
+            }
+        }
+
+        // Try context-based names
+        let context_names = self.generate_context_names(context);
+        for context_name in context_names {
+            if let Some(icon_names) = mapper.get_icon_names(&context_name) {
+                debug!("MappingStrategy: Found context-based mapping '{}' -> {:?}", 
+                       context_name, icon_names);
+                
+                if let Some(first_name) = icon_names.first() {
+                    let metadata = IconMetadata::new(IconFormat::Other("mapped".to_string()));
+                    
+                    return Some(IconResult::new(
+                        std::path::PathBuf::from(first_name),
+                        "MappingStrategy".to_string(),
+                        0.6, // Medium confidence - context-based match
+                        metadata,
+                    ));
+                }
+            }
+        }
+
+        debug!("MappingStrategy: No mapping found for class '{}'", context.class);
+        None
+    }
+
+    fn priority(&self) -> u8 {
+        60 // High priority - explicit mappings should be preferred
+    }
+
+    fn name(&self) -> &'static str {
+        "MappingStrategy"
+    }
+
+    fn is_available(&self) -> bool {
+        // Available if we have any mappings
+        self.mapper.read()
+            .map(|mapper| mapper.mapping_count() > 0)
+            .unwrap_or(false)
+    }
+
+    fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mapper = self.mapper.read()
+            .map_err(|e| format!("Failed to acquire read lock: {}", e))?;
+        
+        debug!("MappingStrategy: Initialized with {} mappings", mapper.mapping_count());
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {
+        debug!("MappingStrategy: Cleanup completed");
+    }
+}
+
+impl Default for MappingStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_application_mapper_creation() {
+        let mapper = ApplicationMapper::new();
+        assert!(mapper.mapping_count() > 0); // Should have default mappings
+        assert!(mapper.has_mapping("firefox"));
+        assert!(mapper.has_mapping("Google-chrome"));
+    }
+
+    #[test]
+    fn test_application_mapper_custom_mappings() {
+        let mut custom_mappings = HashMap::new();
+        custom_mappings.insert("test-app".to_string(), vec!["test-icon".to_string()]);
+        
+        let mapper = ApplicationMapper::with_custom_mappings(custom_mappings);
+        assert_eq!(mapper.mapping_count(), 1);
+        assert!(mapper.has_mapping("test-app"));
+        assert!(!mapper.has_mapping("firefox")); // Should not have defaults
+    }
+
+    #[test]
+    fn test_add_mapping() {
+        let mut mapper = ApplicationMapper::new();
+        let initial_count = mapper.mapping_count();
+        
+        mapper.add_mapping("new-app".to_string(), vec!["new-icon".to_string(), "alt-icon".to_string()]);
+        
+        assert_eq!(mapper.mapping_count(), initial_count + 1);
+        assert!(mapper.has_mapping("new-app"));
+        
+        let icon_names = mapper.get_icon_names("new-app").unwrap();
+        assert_eq!(icon_names.len(), 2);
+        assert_eq!(icon_names[0], "new-icon");
+        assert_eq!(icon_names[1], "alt-icon");
+    }
+
+    #[test]
+    fn test_add_alias() {
+        let mut mapper = ApplicationMapper::new();
+        
+        mapper.add_alias("firefox".to_string(), "firefox-esr".to_string());
+        
+        let icon_names = mapper.get_icon_names("firefox").unwrap();
+        assert!(icon_names.contains(&"firefox-esr".to_string()));
+    }
+
+    #[test]
+    fn test_get_icon_names_case_insensitive() {
+        let mapper = ApplicationMapper::new();
+        
+        // Test exact match
+        assert!(mapper.get_icon_names("firefox").is_some());
+        
+        // Test case-insensitive match
+        assert!(mapper.get_icon_names("FIREFOX").is_some());
+        assert!(mapper.get_icon_names("Firefox").is_some());
+    }
+
+    #[test]
+    fn test_reverse_mapping() {
+        let mapper = ApplicationMapper::new();
+        
+        // Should have reverse mapping for preferred icon names
+        assert!(mapper.get_preferred_class("firefox").is_some());
+        assert!(mapper.get_preferred_class("google-chrome").is_some());
+    }
+
+    #[test]
+    fn test_empty_icon_names() {
+        let mut mapper = ApplicationMapper::new();
+        let initial_count = mapper.mapping_count();
+        
+        // Adding empty icon names should be ignored
+        mapper.add_mapping("empty-app".to_string(), vec![]);
+        
+        assert_eq!(mapper.mapping_count(), initial_count);
+        assert!(!mapper.has_mapping("empty-app"));
+    }
+
+    #[test]
+    fn test_merge_mappers() {
+        let mut mapper1 = ApplicationMapper::new();
+        let mut mapper2 = ApplicationMapper::new();
+        
+        // Add unique mapping to mapper2
+        mapper2.add_mapping("unique-app".to_string(), vec!["unique-icon".to_string()]);
+        
+        // Add additional alias to existing app in mapper2
+        mapper2.add_alias("firefox".to_string(), "firefox-custom".to_string());
+        
+        let initial_count = mapper1.mapping_count();
+        mapper1.merge(&mapper2);
+        
+        // Should have one more mapping
+        assert_eq!(mapper1.mapping_count(), initial_count + 1);
+        
+        // Should have the unique mapping
+        assert!(mapper1.has_mapping("unique-app"));
+        
+        // Should have the additional alias for firefox
+        let firefox_names = mapper1.get_icon_names("firefox").unwrap();
+        assert!(firefox_names.contains(&"firefox-custom".to_string()));
+    }
+
+    #[test]
+    fn test_clear_mappings() {
+        let mut mapper = ApplicationMapper::new();
+        assert!(mapper.mapping_count() > 0);
+        
+        mapper.clear();
+        assert_eq!(mapper.mapping_count(), 0);
+        assert!(!mapper.has_mapping("firefox"));
+    }
+
+    #[test]
+    fn test_mapping_strategy_creation() {
+        let strategy = MappingStrategy::new();
+        assert_eq!(strategy.name(), "MappingStrategy");
+        assert_eq!(strategy.priority(), 60);
+        assert!(strategy.is_available());
+    }
+
+    #[test]
+    fn test_mapping_strategy_with_custom_mappings() {
+        let mut mappings = HashMap::new();
+        mappings.insert("test-class".to_string(), vec!["test-icon".to_string()]);
+        
+        let strategy = MappingStrategy::with_mappings(mappings);
+        assert!(strategy.is_available());
+        
+        let mapper = strategy.get_mapper().unwrap();
+        assert!(mapper.has_mapping("test-class"));
+    }
+
+    #[test]
+    fn test_mapping_strategy_exact_match() {
+        let strategy = MappingStrategy::new();
+        
+        let context = IconContext::new("firefox".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+        assert_eq!(result.confidence, 0.9); // High confidence for exact match
+        assert_eq!(result.path.to_string_lossy(), "firefox");
+    }
+
+    #[test]
+    fn test_mapping_strategy_case_insensitive_match() {
+        let strategy = MappingStrategy::new();
+        
+        let context = IconContext::new("FIREFOX".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+        assert_eq!(result.confidence, 0.9);
+    }
+
+    #[test]
+    fn test_mapping_strategy_fuzzy_matching() {
+        let strategy = MappingStrategy::new();
+        
+        // Test partial match
+        let context = IconContext::new("firefox-esr".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+        assert_eq!(result.confidence, 0.7); // Medium-high confidence for fuzzy match
+    }
+
+    #[test]
+    fn test_mapping_strategy_fuzzy_matching_disabled() {
+        let strategy = MappingStrategy::new().with_fuzzy_matching(false);
+        
+        // Should not find fuzzy matches when disabled
+        let context = IconContext::new("firefox-esr".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_mapping_strategy_context_based_matching() {
+        let strategy = MappingStrategy::new();
+        
+        // Test matching based on executable name
+        let context = IconContext::new("unknown-class".to_string())
+            .with_executable("firefox".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+        assert_eq!(result.confidence, 0.6); // Medium confidence for context match
+    }
+
+    #[test]
+    fn test_mapping_strategy_title_based_matching() {
+        let strategy = MappingStrategy::new();
+        
+        // Test matching based on window title
+        let context = IconContext::with_title("unknown-class".to_string(), "Firefox - Mozilla Firefox".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+        assert_eq!(result.confidence, 0.6);
+    }
+
+    #[test]
+    fn test_mapping_strategy_no_match() {
+        let strategy = MappingStrategy::new();
+        
+        let context = IconContext::new("completely-unknown-app".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_mapping_strategy_add_mapping() {
+        let strategy = MappingStrategy::new();
+        
+        // Add a new mapping
+        let result = strategy.add_mapping(
+            "new-app".to_string(), 
+            vec!["new-icon".to_string()]
+        );
+        assert!(result.is_ok());
+        
+        // Test that the new mapping works
+        let context = IconContext::new("new-app".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.path.to_string_lossy(), "new-icon");
+    }
+
+    #[test]
+    fn test_mapping_strategy_add_alias() {
+        let strategy = MappingStrategy::new();
+        
+        // Add an alias to existing mapping
+        let result = strategy.add_alias("firefox".to_string(), "firefox-test".to_string());
+        assert!(result.is_ok());
+        
+        // Verify the alias was added
+        let mapper = strategy.get_mapper().unwrap();
+        let icon_names = mapper.get_icon_names("firefox").unwrap();
+        assert!(icon_names.contains(&"firefox-test".to_string()));
+    }
+
+    #[test]
+    fn test_default_mappings_coverage() {
+        let mapper = ApplicationMapper::new();
+        
+        // Test that we have mappings for common application categories
+        
+        // Web browsers
+        assert!(mapper.has_mapping("firefox"));
+        assert!(mapper.has_mapping("Google-chrome"));
+        assert!(mapper.has_mapping("chromium-browser"));
+        
+        // Text editors
+        assert!(mapper.has_mapping("code"));
+        assert!(mapper.has_mapping("nvim"));
+        
+        // Terminals
+        assert!(mapper.has_mapping("Alacritty"));
+        assert!(mapper.has_mapping("kitty"));
+        
+        // File managers
+        assert!(mapper.has_mapping("nautilus"));
+        assert!(mapper.has_mapping("dolphin"));
+        
+        // Media applications
+        assert!(mapper.has_mapping("vlc"));
+        assert!(mapper.has_mapping("spotify"));
+        
+        // Communication
+        assert!(mapper.has_mapping("discord"));
+        assert!(mapper.has_mapping("slack"));
+        
+        // Development tools
+        assert!(mapper.has_mapping("jetbrains-idea"));
+        assert!(mapper.has_mapping("DBeaver"));
+        
+        // Graphics
+        assert!(mapper.has_mapping("gimp"));
+        assert!(mapper.has_mapping("inkscape"));
+        
+        // Office
+        assert!(mapper.has_mapping("libreoffice-writer"));
+        
+        // System
+        assert!(mapper.has_mapping("gnome-system-monitor"));
+    }
+
+    #[test]
+    fn test_multiple_aliases_per_application() {
+        let mapper = ApplicationMapper::new();
+        
+        // Test that applications have multiple aliases
+        let firefox_names = mapper.get_icon_names("firefox").unwrap();
+        assert!(firefox_names.len() > 1);
+        assert!(firefox_names.contains(&"firefox".to_string()));
+        assert!(firefox_names.contains(&"Firefox".to_string()));
+        
+        let chrome_names = mapper.get_icon_names("Google-chrome").unwrap();
+        assert!(chrome_names.len() > 1);
+        assert!(chrome_names.contains(&"google-chrome".to_string()));
+        assert!(chrome_names.contains(&"chrome".to_string()));
+    }
+
+    #[test]
+    fn test_fuzzy_matching_with_prefixes() {
+        let strategy = MappingStrategy::new();
+        
+        // Test matching with common prefixes
+        let context = IconContext::new("org.mozilla.firefox".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+    }
+
+    #[test]
+    fn test_fuzzy_matching_with_separators() {
+        let strategy = MappingStrategy::new();
+        
+        // Test matching with different separators
+        let context = IconContext::new("google_chrome".to_string());
+        let result = strategy.detect_icon(&context);
+        
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.strategy_used, "MappingStrategy");
+    }
+
+    #[test]
+    fn test_generate_context_names() {
+        let strategy = MappingStrategy::new();
+        
+        let context = IconContext::with_title("unknown".to_string(), "Mozilla Firefox - Private Browsing".to_string())
+            .with_executable("firefox".to_string());
+        
+        let names = strategy.generate_context_names(&context);
+        
+        assert!(names.contains(&"firefox".to_string()));
+        assert!(names.contains(&"mozilla firefox".to_string()));
+    }
+
+    #[test]
+    fn test_strategy_initialization() {
+        let mut strategy = MappingStrategy::new();
+        let result = strategy.initialize();
+        
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_strategy_availability() {
+        // Strategy with mappings should be available
+        let strategy = MappingStrategy::new();
+        assert!(strategy.is_available());
+        
+        // Strategy with no mappings should not be available
+        let empty_mappings = HashMap::new();
+        let empty_strategy = MappingStrategy::with_mappings(empty_mappings);
+        assert!(!empty_strategy.is_available());
+    }
+
+    #[test]
+    fn test_confidence_levels() {
+        let strategy = MappingStrategy::new();
+        
+        // Exact match should have highest confidence
+        let exact_context = IconContext::new("firefox".to_string());
+        let exact_result = strategy.detect_icon(&exact_context).unwrap();
+        assert_eq!(exact_result.confidence, 0.9);
+        
+        // Fuzzy match should have medium-high confidence
+        let fuzzy_context = IconContext::new("firefox-esr".to_string());
+        let fuzzy_result = strategy.detect_icon(&fuzzy_context).unwrap();
+        assert_eq!(fuzzy_result.confidence, 0.7);
+        
+        // Context match should have medium confidence
+        let context_match = IconContext::new("unknown".to_string())
+            .with_executable("firefox".to_string());
+        let context_result = strategy.detect_icon(&context_match).unwrap();
+        assert_eq!(context_result.confidence, 0.6);
+    }
+
+    #[test]
+    fn test_icon_format_in_result() {
+        let strategy = MappingStrategy::new();
+        
+        let context = IconContext::new("firefox".to_string());
+        let result = strategy.detect_icon(&context).unwrap();
+        
+        // MappingStrategy should return "mapped" format
+        assert!(matches!(result.metadata.format, IconFormat::Other(ref s) if s == "mapped"));
+    }
+}

--- a/src/icon/strategies/mod.rs
+++ b/src/icon/strategies/mod.rs
@@ -1,0 +1,10 @@
+pub mod directory;
+pub mod mapping;
+pub mod hyprland;
+
+#[cfg(test)]
+mod examples;
+
+pub use directory::DirectoryStrategy;
+pub use mapping::{MappingStrategy, ApplicationMapper};
+pub use hyprland::HyprlandStrategy;

--- a/src/icon/traits.rs
+++ b/src/icon/traits.rs
@@ -1,0 +1,60 @@
+use crate::icon::types::{IconContext, IconResult};
+
+/// Trait for icon detection strategies
+/// 
+/// Each strategy implements a different method for finding icons based on
+/// the provided context information. Strategies are executed in priority order
+/// until one returns a successful result.
+pub trait IconDetectionStrategy: Send + Sync {
+    /// Attempt to detect an icon for the given context
+    /// 
+    /// Returns Some(IconResult) if an icon is found, None otherwise.
+    /// Should not panic - any errors should be logged and None returned.
+    fn detect_icon(&self, context: &IconContext) -> Option<IconResult>;
+
+    /// Priority of this strategy (higher values = higher priority)
+    /// 
+    /// Strategies with higher priority values are executed first.
+    /// Typical priority ranges:
+    /// - 100+: Custom/user-defined paths (highest priority)
+    /// - 50-99: Application-specific strategies
+    /// - 10-49: General detection strategies
+    /// - 1-9: Fallback strategies (lowest priority)
+    fn priority(&self) -> u8;
+
+    /// Human-readable name of this strategy for logging and debugging
+    fn name(&self) -> &'static str;
+
+    /// Optional: Check if this strategy is available/enabled
+    /// 
+    /// Default implementation returns true. Strategies can override this
+    /// to check for required dependencies, configuration, etc.
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    /// Optional: Initialize the strategy
+    /// 
+    /// Called once when the strategy is registered. Can be used for
+    /// one-time setup, validation, etc. Default implementation does nothing.
+    fn initialize(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+
+    /// Optional: Cleanup when strategy is no longer needed
+    /// 
+    /// Called when the strategy is being removed or the system is shutting down.
+    /// Default implementation does nothing.
+    fn cleanup(&mut self) {}
+}
+
+/// Trait for components that can provide icon detection strategies
+/// 
+/// This allows for modular registration of strategies from different sources
+pub trait StrategyProvider {
+    /// Get all strategies provided by this provider
+    fn get_strategies(&self) -> Vec<Box<dyn IconDetectionStrategy>>;
+    
+    /// Get the name of this provider for logging
+    fn provider_name(&self) -> &'static str;
+}

--- a/src/icon/types.rs
+++ b/src/icon/types.rs
@@ -1,0 +1,250 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+/// Context information available for icon detection
+#[derive(Debug, Clone)]
+pub struct IconContext {
+    /// Window class from Hyprland
+    pub class: String,
+    /// Window title from Hyprland (optional)
+    pub title: Option<String>,
+    /// Executable name if available
+    pub executable: Option<String>,
+    /// Process ID if available
+    pub pid: Option<u32>,
+    /// Workspace information if available
+    pub workspace: Option<String>,
+}
+
+impl IconContext {
+    /// Create a new IconContext with just the class
+    pub fn new(class: String) -> Self {
+        Self {
+            class,
+            title: None,
+            executable: None,
+            pid: None,
+            workspace: None,
+        }
+    }
+
+    /// Create a new IconContext with class and title
+    pub fn with_title(class: String, title: String) -> Self {
+        Self {
+            class,
+            title: Some(title),
+            executable: None,
+            pid: None,
+            workspace: None,
+        }
+    }
+
+    /// Add executable information to the context
+    pub fn with_executable(mut self, executable: String) -> Self {
+        self.executable = Some(executable);
+        self
+    }
+
+    /// Add process ID to the context
+    pub fn with_pid(mut self, pid: u32) -> Self {
+        self.pid = Some(pid);
+        self
+    }
+
+    /// Add workspace information to the context
+    pub fn with_workspace(mut self, workspace: String) -> Self {
+        self.workspace = Some(workspace);
+        self
+    }
+}
+
+/// Result of icon detection containing path and metadata
+#[derive(Debug, Clone)]
+pub struct IconResult {
+    /// Path to the icon file
+    pub path: PathBuf,
+    /// Name of the strategy that found this icon
+    pub strategy_used: String,
+    /// Confidence level of this result (0.0 - 1.0)
+    pub confidence: f32,
+    /// Additional metadata about the icon
+    pub metadata: IconMetadata,
+}
+
+impl IconResult {
+    /// Create a new IconResult
+    pub fn new(
+        path: PathBuf,
+        strategy_used: String,
+        confidence: f32,
+        metadata: IconMetadata,
+    ) -> Self {
+        Self {
+            path,
+            strategy_used,
+            confidence,
+            metadata,
+        }
+    }
+}
+
+/// Metadata about an icon file
+#[derive(Debug, Clone)]
+pub struct IconMetadata {
+    /// Format of the icon file
+    pub format: IconFormat,
+    /// Size of the icon if known
+    pub size: Option<(u32, u32)>,
+    /// Icon theme if applicable
+    pub theme: Option<String>,
+    /// When this metadata was created
+    pub created_at: Instant,
+}
+
+impl IconMetadata {
+    /// Create new metadata with format
+    pub fn new(format: IconFormat) -> Self {
+        Self {
+            format,
+            size: None,
+            theme: None,
+            created_at: Instant::now(),
+        }
+    }
+
+    /// Create metadata with format and size
+    pub fn with_size(format: IconFormat, size: (u32, u32)) -> Self {
+        Self {
+            format,
+            size: Some(size),
+            theme: None,
+            created_at: Instant::now(),
+        }
+    }
+
+    /// Create metadata with format and theme
+    pub fn with_theme(format: IconFormat, theme: String) -> Self {
+        Self {
+            format,
+            size: None,
+            theme: Some(theme),
+            created_at: Instant::now(),
+        }
+    }
+
+    /// Create metadata with all information
+    pub fn complete(format: IconFormat, size: (u32, u32), theme: String) -> Self {
+        Self {
+            format,
+            size: Some(size),
+            theme: Some(theme),
+            created_at: Instant::now(),
+        }
+    }
+}
+
+/// Supported icon formats
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IconFormat {
+    /// SVG vector format
+    Svg,
+    /// PNG raster format
+    Png,
+    /// XPM format
+    Xpm,
+    /// Other format with extension
+    Other(String),
+}
+
+impl IconFormat {
+    /// Create IconFormat from file extension
+    pub fn from_extension(ext: &str) -> Self {
+        match ext.to_lowercase().as_str() {
+            "svg" => IconFormat::Svg,
+            "png" => IconFormat::Png,
+            "xpm" => IconFormat::Xpm,
+            other => IconFormat::Other(other.to_string()),
+        }
+    }
+
+    /// Get the file extension for this format
+    pub fn extension(&self) -> &str {
+        match self {
+            IconFormat::Svg => "svg",
+            IconFormat::Png => "png",
+            IconFormat::Xpm => "xpm",
+            IconFormat::Other(ext) => ext,
+        }
+    }
+
+    /// Check if this is a vector format
+    pub fn is_vector(&self) -> bool {
+        matches!(self, IconFormat::Svg)
+    }
+
+    /// Check if this is a raster format
+    pub fn is_raster(&self) -> bool {
+        matches!(self, IconFormat::Png | IconFormat::Xpm | IconFormat::Other(_))
+    }
+}
+
+/// Error types for icon operations
+#[derive(Debug, thiserror::Error)]
+pub enum IconError {
+    #[error("No icon found for class: {class}")]
+    NotFound { class: String },
+    
+    #[error("Failed to load icon from path: {path}")]
+    LoadError { 
+        path: PathBuf, 
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>
+    },
+    
+    #[error("Invalid icon format: {format}")]
+    InvalidFormat { format: String },
+    
+    #[error("Cache error: {message}")]
+    CacheError { message: String },
+    
+    #[error("Strategy error in {strategy}: {message}")]
+    StrategyError { strategy: String, message: String },
+    
+    #[error("Configuration error: {message}")]
+    ConfigError { message: String },
+}
+
+impl IconError {
+    /// Create a NotFound error
+    pub fn not_found(class: impl Into<String>) -> Self {
+        Self::NotFound { class: class.into() }
+    }
+
+    /// Create a LoadError
+    pub fn load_error(path: PathBuf, source: Box<dyn std::error::Error + Send + Sync>) -> Self {
+        Self::LoadError { path, source }
+    }
+
+    /// Create an InvalidFormat error
+    pub fn invalid_format(format: impl Into<String>) -> Self {
+        Self::InvalidFormat { format: format.into() }
+    }
+
+    /// Create a CacheError
+    pub fn cache_error(message: impl Into<String>) -> Self {
+        Self::CacheError { message: message.into() }
+    }
+
+    /// Create a StrategyError
+    pub fn strategy_error(strategy: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::StrategyError { 
+            strategy: strategy.into(), 
+            message: message.into() 
+        }
+    }
+
+    /// Create a ConfigError
+    pub fn config_error(message: impl Into<String>) -> Self {
+        Self::ConfigError { message: message.into() }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,10 +132,11 @@ fn setup(
 
     let mut all_apps: Vec<(String, Option<Client>, bool)> = Vec::new();
     let mut initial_order = Vec::new();
-    let mut processed_favorites = HashSet::new();
+    let mut processed_classes = HashSet::new();
 
+    // Primeiro, adiciona os favoritos na ordem salva
     for fav_class in &favorites.0 {
-        if processed_favorites.contains(fav_class) {
+        if processed_classes.contains(fav_class) {
             continue;
         }
 
@@ -147,13 +148,15 @@ fn setup(
         } else {
             initial_order.push(format!("pinned:{}", fav_class));
         }
-        processed_favorites.insert(fav_class.clone());
+        processed_classes.insert(fav_class.clone());
     }
 
+    // Depois, adiciona as aplicações não-favoritas que estão abertas
     for client in &client_list.0 {
-        if !favorites.0.contains(&client.class) {
+        if !processed_classes.contains(&client.class) {
             all_apps.push((client.class.clone(), Some(client.clone()), false));
             initial_order.push(client.address.clone());
+            processed_classes.insert(client.class.clone());
         }
     }
 
@@ -186,32 +189,17 @@ fn setup(
             index,
         );
 
-        commands.entity(icon_entity).insert(HoverTarget {
-            original_position: translation.truncate(),
-            original_z: translation.z,
-            original_scale: scale,
-            index,
-            is_hovered: false,
-            hover_exit_timer: None,
-        });
-
         if let Some(client) = client_opt {
             add_client_address(&mut commands, icon_entity, client.address.clone());
             commands
                 .entity(icon_entity)
                 .insert(ClientAddress(client.address.clone()));
-            commands
-                .entity(icon_entity)
-                .insert(ClientClass(client.class.clone()));
         } else if *is_favorite {
             let placeholder_address = format!("pinned:{}", class);
             add_client_address(&mut commands, icon_entity, placeholder_address.clone());
             commands
                 .entity(icon_entity)
                 .insert(ClientAddress(placeholder_address));
-            commands
-                .entity(icon_entity)
-                .insert(ClientClass(class.clone()));
         }
 
         if *is_favorite {
@@ -317,7 +305,29 @@ fn toggle_favorite(
     } else {
         info!("Adding favorite: {}", app_class);
         if !favorites.0.contains(&app_class.to_string()) {
+            // Adiciona o favorito no final da lista de favoritos
             favorites.0.push(app_class.to_string());
+            
+            // Atualiza a ordem na dock para mover o item para a posição correta
+            if let Some(current_addr) = q_address {
+                let current_addr_str = current_addr.0.clone();
+                
+                // Remove o endereço atual da ordem
+                dock_order.0.retain(|a| a != &current_addr_str);
+                
+                // Encontra a posição onde inserir (após os outros favoritos)
+                let mut insert_pos = 0;
+                for addr in &dock_order.0 {
+                    if addr.starts_with("pinned:") {
+                        insert_pos += 1;
+                    } else {
+                        break;
+                    }
+                }
+                
+                // Insere na posição correta
+                dock_order.0.insert(insert_pos, current_addr_str);
+            }
         }
         add_favorite(commands, entity, images, config);
         reorder_trigger.0 = true;
@@ -518,6 +528,15 @@ fn process_new_windows(
 ) {
 
     for (_index, client) in new_windows.iter().enumerate() {
+        // Verifica se já existe um ícone para este endereço
+        if q_entities.iter().any(|(_, addr_opt, _, _)| {
+            addr_opt.map_or(false, |a| a.0 == client.address)
+        }) {
+            info!("Window already exists in dock: {}", client.address);
+            continue;
+        }
+
+        // Verifica se existe um ícone pinned para esta classe
         if let Some((entity, _, _, Some(mut sprite))) = q_entities.iter_mut().find(|(_, addr_opt, class_opt, _)| {
             addr_opt.map_or(false, |a| a.0.starts_with("pinned:"))
                 && class_opt.map_or(false, |c| c.0 == client.class)
@@ -560,22 +579,10 @@ fn process_new_windows(
             0,
         );
 
-        commands.entity(icon_entity).insert(HoverTarget {
-            original_position: translation.truncate(),
-            original_z: translation.z,
-            original_scale: scale,
-            index: 0,
-            is_hovered: false,
-            hover_exit_timer: None,
-        });
-
         add_client_address(commands, icon_entity, client.address.clone());
         commands
             .entity(icon_entity)
             .insert(ClientAddress(client.address.clone()));
-        commands
-            .entity(icon_entity)
-            .insert(ClientClass(client.class.clone()));
 
         if show_titles.0 {
             add_icon_text(
@@ -721,6 +728,14 @@ fn handle_hypr_open_window(
     class: String,
     title: String,
 ) {
+    // Verifica se já existe um ícone para este endereço
+    if q_entities.iter().any(|(_, addr_opt, _, _)| {
+        addr_opt.map_or(false, |a| a.0 == address)
+    }) {
+        info!("Window already exists in dock: {}", address);
+        return;
+    }
+
     let client = Client {
         address: address.clone(),
         class: class.clone(),
@@ -769,22 +784,10 @@ fn handle_hypr_open_window(
         0,
     );
 
-    commands.entity(icon_entity).insert(HoverTarget {
-        original_position: translation.truncate(),
-        original_z: translation.z,
-        original_scale: scale,
-        index: 0,
-        is_hovered: false,
-        hover_exit_timer: None,
-    });
-
     add_client_address(commands, icon_entity, client.address.clone());
     commands
         .entity(icon_entity)
         .insert(ClientAddress(client.address.clone()));
-    commands
-        .entity(icon_entity)
-        .insert(ClientClass(client.class.clone()));
 
     if show_titles.0 {
         add_icon_text(

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,7 @@ fn toggle_favorite(
                     }
                 }
             }
+            // Reorder will be triggered and will move this to non-favorites section
         } else {
             // App is not running, it only exists because it was a favorite.
             // Despawn the whole thing.
@@ -305,31 +306,12 @@ fn toggle_favorite(
     } else {
         info!("Adding favorite: {}", app_class);
         if !favorites.0.contains(&app_class.to_string()) {
-            // Adiciona o favorito no final da lista de favoritos
+            // Add favorite to the list
             favorites.0.push(app_class.to_string());
-            
-            // Atualiza a ordem na dock para mover o item para a posição correta
-            if let Some(current_addr) = q_address {
-                let current_addr_str = current_addr.0.clone();
-                
-                // Remove o endereço atual da ordem
-                dock_order.0.retain(|a| a != &current_addr_str);
-                
-                // Encontra a posição onde inserir (após os outros favoritos)
-                let mut insert_pos = 0;
-                for addr in &dock_order.0 {
-                    if addr.starts_with("pinned:") {
-                        insert_pos += 1;
-                    } else {
-                        break;
-                    }
-                }
-                
-                // Insere na posição correta
-                dock_order.0.insert(insert_pos, current_addr_str);
-            }
         }
         add_favorite(commands, entity, images, config);
+        
+        // Trigger full reorder to place favorites correctly
         reorder_trigger.0 = true;
     }
     save_favorites(favorites);

--- a/src/systems/icon.rs
+++ b/src/systems/icon.rs
@@ -1,7 +1,7 @@
 use crate::types::*;
 use crate::config::Config;
 use crate::utils::calculate_icon_transform;
-use crate::IconText;
+use crate::{IconText, Favorite, Favorites};
 use bevy::prelude::*;
 use bevy::window::PrimaryWindow;
 
@@ -35,13 +35,44 @@ pub fn update_text_positions(
 }
 
 pub fn reorder_icons_system(
-    mut q_icons: Query<(Entity, &ClientAddress, &mut Transform, &mut HoverTarget)>,
-    dock_order: Res<DockOrder>,
+    mut q_icons: Query<(Entity, &ClientAddress, &ClientClass, &mut Transform, &mut HoverTarget, Option<&Favorite>)>,
+    mut dock_order: ResMut<DockOrder>,
+    favorites: Res<Favorites>,
     windows: Query<&Window, With<PrimaryWindow>>,
     scroll_state: Res<ScrollState>,
     config: Res<Config>,
     mut reorder_trigger: ResMut<ReorderTrigger>,
 ) {
+    if reorder_trigger.0 {
+        // Rebuild dock_order to ensure favorites are first
+        let mut new_order = Vec::new();
+        let mut non_favorite_addresses = Vec::new();
+        
+        // Collect all current addresses with their classes
+        let mut address_to_class: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        for (_, addr, class, _, _, _) in q_icons.iter() {
+            address_to_class.insert(addr.0.clone(), class.0.clone());
+        }
+        
+        // First, add favorites in order
+        for fav_class in &favorites.0 {
+            // Find the address for this favorite class
+            if let Some((_, addr, _, _, _, _)) = q_icons.iter().find(|(_, _, class, _, _, _)| &class.0 == fav_class) {
+                new_order.push(addr.0.clone());
+            }
+        }
+        
+        // Then, add non-favorites
+        for (_, addr, _, _, _, favorite_opt) in q_icons.iter() {
+            if favorite_opt.is_none() && !new_order.contains(&addr.0) {
+                non_favorite_addresses.push(addr.0.clone());
+            }
+        }
+        
+        new_order.extend(non_favorite_addresses);
+        dock_order.0 = new_order;
+    }
+    
     let window = windows.single();
     let start_x = -window.width() / 2.0 + config.margin_x;
     let start_y = -window.height() / 2.0 + config.margin_y;
@@ -53,7 +84,7 @@ pub fn reorder_icons_system(
         let (translation, scale) =
             calculate_icon_transform(index, start_pos, direction, &config, scroll_state.offset);
 
-        for (_entity, icon_address, mut transform, mut hover) in q_icons.iter_mut() {
+        for (_entity, icon_address, _, mut transform, mut hover, _) in q_icons.iter_mut() {
             if icon_address.0 == *address {
                 let current_pos = transform.translation;
                 let target_pos = translation;


### PR DESCRIPTION
fix: prevent icon duplication and fix favorites ordering

This commit addresses critical bugs in dock icon management and
favorites ordering system.

Bugs Fixed:
- Duplicate icons created when windows open (missing validation)
- Favorites not repositioning when toggled on/off
- Incorrect icon indices causing keybind issues
- Manual dock_order manipulation causing ordering inconsistencies

Changes:
- Add duplicate check in handle_hypr_open_window and process_new_windows
- Implement automatic dock_order rebuild in reorder_icons_system
- Simplify toggle_favorite logic to delegate ordering to reorder system
- Remove duplicate component insertions (HoverTarget, ClientClass)
- Use Favorite component to determine correct icon ordering
- Ensure favorites always appear first, followed by non-favorites

The reorder_icons_system now intelligently rebuilds dock_order when
triggered, using the Favorite component and favorites list to maintain
correct ordering. This eliminates complex manual ordering logic and
ensures consistency across all operations.